### PR TITLE
feat: implement paso use project command for session context

### DIFF
--- a/internal/cli/column/list.go
+++ b/internal/cli/column/list.go
@@ -31,11 +31,8 @@ Examples:
 		RunE: runList,
 	}
 
-	// Required flags
-	cmd.Flags().Int("project", 0, "Project ID (required)")
-	if err := cmd.MarkFlagRequired("project"); err != nil {
-		log.Printf("Error marking flag as required: %v", err)
-	}
+	// Flags
+	cmd.Flags().Int("project", 0, "Project ID (uses PASO_PROJECT env var if not specified)")
 
 	// Agent-friendly flags
 	cmd.Flags().Bool("json", false, "Output in JSON format")
@@ -47,11 +44,21 @@ Examples:
 func runList(cmd *cobra.Command, args []string) error {
 	ctx := context.Background()
 
-	columnProject, _ := cmd.Flags().GetInt("project")
 	jsonOutput, _ := cmd.Flags().GetBool("json")
 	quietMode, _ := cmd.Flags().GetBool("quiet")
 
 	formatter := &cli.OutputFormatter{JSON: jsonOutput, Quiet: quietMode}
+
+	// Get project ID from flag or environment variable
+	columnProject, err := cli.GetProjectID(cmd)
+	if err != nil {
+		if fmtErr := formatter.ErrorWithSuggestion("NO_PROJECT",
+			err.Error(),
+			"Set project with: eval $(paso use project <project-id>)"); fmtErr != nil {
+			log.Printf("Error formatting error message: %v", fmtErr)
+		}
+		os.Exit(cli.ExitUsage)
+	}
 
 	// Initialize CLI
 	cliInstance, err := cli.NewCLI(ctx)

--- a/internal/cli/label/list.go
+++ b/internal/cli/label/list.go
@@ -32,11 +32,8 @@ Examples:
 		RunE: runList,
 	}
 
-	// Required flags
-	cmd.Flags().Int("project", 0, "Project ID (required)")
-	if err := cmd.MarkFlagRequired("project"); err != nil {
-		log.Printf("Error marking flag as required: %v", err)
-	}
+	// Flags
+	cmd.Flags().Int("project", 0, "Project ID (uses PASO_PROJECT env var if not specified)")
 
 	// Agent-friendly flags
 	cmd.Flags().Bool("json", false, "Output in JSON format")
@@ -47,11 +44,21 @@ Examples:
 
 func runList(cmd *cobra.Command, args []string) error {
 	ctx := context.Background()
-	labelProject, _ := cmd.Flags().GetInt("project")
 	jsonOutput, _ := cmd.Flags().GetBool("json")
 	quietMode, _ := cmd.Flags().GetBool("quiet")
 
 	formatter := &cli.OutputFormatter{JSON: jsonOutput, Quiet: quietMode}
+
+	// Get project ID from flag or environment variable
+	labelProject, err := cli.GetProjectID(cmd)
+	if err != nil {
+		if fmtErr := formatter.ErrorWithSuggestion("NO_PROJECT",
+			err.Error(),
+			"Set project with: eval $(paso use project <project-id>)"); fmtErr != nil {
+			log.Printf("Error formatting error message: %v", fmtErr)
+		}
+		os.Exit(cli.ExitUsage)
+	}
 
 	// Initialize CLI
 	cliInstance, err := cli.NewCLI(ctx)

--- a/internal/cli/task/blocked.go
+++ b/internal/cli/task/blocked.go
@@ -35,11 +35,8 @@ Examples:
 		RunE: runBlocked,
 	}
 
-	// Required flags
-	cmd.Flags().Int("project", 0, "Project ID (required)")
-	if err := cmd.MarkFlagRequired("project"); err != nil {
-		log.Printf("Error marking flag as required: %v", err)
-	}
+	// Flags
+	cmd.Flags().Int("project", 0, "Project ID (uses PASO_PROJECT env var if not specified)")
 
 	// Agent-friendly flags
 	cmd.Flags().Bool("json", false, "Output in JSON format")
@@ -51,11 +48,21 @@ Examples:
 func runBlocked(cmd *cobra.Command, args []string) error {
 	ctx := context.Background()
 
-	taskProject, _ := cmd.Flags().GetInt("project")
 	jsonOutput, _ := cmd.Flags().GetBool("json")
 	quietMode, _ := cmd.Flags().GetBool("quiet")
 
 	formatter := &cli.OutputFormatter{JSON: jsonOutput, Quiet: quietMode}
+
+	// Get project ID from flag or environment variable
+	taskProject, err := cli.GetProjectID(cmd)
+	if err != nil {
+		if fmtErr := formatter.ErrorWithSuggestion("NO_PROJECT",
+			err.Error(),
+			"Set project with: eval $(paso use project <project-id>)"); fmtErr != nil {
+			log.Printf("Error formatting error message: %v", fmtErr)
+		}
+		os.Exit(cli.ExitUsage)
+	}
 
 	// Initialize CLI
 	cliInstance, err := cli.NewCLI(ctx)

--- a/internal/cli/task/ready.go
+++ b/internal/cli/task/ready.go
@@ -35,11 +35,8 @@ Examples:
 		RunE: runReady,
 	}
 
-	// Required flags
-	cmd.Flags().Int("project", 0, "Project ID (required)")
-	if err := cmd.MarkFlagRequired("project"); err != nil {
-		log.Printf("Error marking flag as required: %v", err)
-	}
+	// Flags
+	cmd.Flags().Int("project", 0, "Project ID (uses PASO_PROJECT env var if not specified)")
 
 	// Agent-friendly flags
 	cmd.Flags().Bool("json", false, "Output in JSON format")
@@ -51,11 +48,21 @@ Examples:
 func runReady(cmd *cobra.Command, args []string) error {
 	ctx := context.Background()
 
-	taskProject, _ := cmd.Flags().GetInt("project")
 	jsonOutput, _ := cmd.Flags().GetBool("json")
 	quietMode, _ := cmd.Flags().GetBool("quiet")
 
 	formatter := &cli.OutputFormatter{JSON: jsonOutput, Quiet: quietMode}
+
+	// Get project ID from flag or environment variable
+	taskProject, err := cli.GetProjectID(cmd)
+	if err != nil {
+		if fmtErr := formatter.ErrorWithSuggestion("NO_PROJECT",
+			err.Error(),
+			"Set project with: eval $(paso use project <project-id>)"); fmtErr != nil {
+			log.Printf("Error formatting error message: %v", fmtErr)
+		}
+		os.Exit(cli.ExitUsage)
+	}
 
 	// Initialize CLI
 	cliInstance, err := cli.NewCLI(ctx)

--- a/internal/cli/use/project.go
+++ b/internal/cli/use/project.go
@@ -1,0 +1,140 @@
+// Package use holds all cli commands related to setting contextual information
+// e.g., paso use ...
+package use
+
+import (
+	"context"
+	"fmt"
+	"log"
+	"os"
+
+	"github.com/spf13/cobra"
+	"github.com/thenoetrevino/paso/internal/cli"
+)
+
+// ProjectCmd returns the use project subcommand
+func ProjectCmd() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "project [project-id]",
+		Short: "Set project context for current shell session",
+		Long: `Set the current project context using environment variables.
+This command outputs shell commands that should be evaluated:
+
+  eval $(paso use project 3)              # Use project 3
+  eval $(paso use project --clear)        # Clear project context
+  paso use project --show                 # Show current project
+
+The PASO_PROJECT environment variable will be set in your current shell
+session only. The --project flag on other commands takes precedence over
+this environment variable.`,
+		Args: cobra.MaximumNArgs(1),
+		RunE: runUseProject,
+	}
+
+	cmd.Flags().Bool("clear", false, "Clear the current project context")
+	cmd.Flags().Bool("show", false, "Show the current project context")
+	cmd.Flags().Bool("dry-run", false, "Show what would be exported without outputting shell commands")
+
+	return cmd
+}
+
+func runUseProject(cmd *cobra.Command, args []string) error {
+	ctx := context.Background()
+
+	clearFlag, _ := cmd.Flags().GetBool("clear")
+	showFlag, _ := cmd.Flags().GetBool("show")
+	dryRun, _ := cmd.Flags().GetBool("dry-run")
+
+	// Handle --show flag
+	if showFlag {
+		return showCurrentProject()
+	}
+
+	// Handle --clear flag
+	if clearFlag {
+		if dryRun {
+			fmt.Fprintf(os.Stderr, "Would clear PASO_PROJECT\n")
+			return nil
+		}
+		fmt.Println("unset PASO_PROJECT")
+		fmt.Fprintf(os.Stderr, "Cleared project context\n")
+		return nil
+	}
+
+	// Validate project ID provided
+	if len(args) == 0 {
+		return fmt.Errorf("project ID required\nUsage: eval $(paso use project <project-id>)")
+	}
+
+	var projectID int
+	if _, err := fmt.Sscanf(args[0], "%d", &projectID); err != nil {
+		return fmt.Errorf("invalid project ID: %s", args[0])
+	}
+
+	// Initialize CLI
+	cliInstance, err := cli.NewCLI(ctx)
+	if err != nil {
+		return fmt.Errorf("initialization error: %w", err)
+	}
+	defer func() {
+		if err := cliInstance.Close(); err != nil {
+			log.Printf("Error closing CLI: %v", err)
+		}
+	}()
+
+	// Validate project exists
+	project, err := cliInstance.App.ProjectService.GetProjectByID(ctx, projectID)
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "Error: project %d not found\n", projectID)
+		fmt.Fprintf(os.Stderr, "Suggestion: Use 'paso project list' to see available projects\n")
+		os.Exit(cli.ExitNotFound)
+	}
+
+	// Output shell export command (to stdout for eval)
+	if dryRun {
+		fmt.Fprintf(os.Stderr, "Would set PASO_PROJECT=%d (%s)\n", projectID, project.Name)
+		return nil
+	}
+
+	fmt.Printf("export PASO_PROJECT=%d\n", projectID)
+	fmt.Fprintf(os.Stderr, "Now using project %d: %s\n", projectID, project.Name)
+
+	return nil
+}
+
+func showCurrentProject() error {
+	currentProject := os.Getenv("PASO_PROJECT")
+	if currentProject == "" {
+		fmt.Println("No project context set")
+		fmt.Println("Use 'eval $(paso use project <project-id>)' to set one")
+		return nil
+	}
+
+	ctx := context.Background()
+	var projectID int
+	if _, err := fmt.Sscanf(currentProject, "%d", &projectID); err != nil {
+		fmt.Printf("Invalid project context: %s\n", currentProject)
+		return nil
+	}
+
+	// Initialize CLI
+	cliInstance, err := cli.NewCLI(ctx)
+	if err != nil {
+		return fmt.Errorf("initialization error: %w", err)
+	}
+	defer func() {
+		if err := cliInstance.Close(); err != nil {
+			log.Printf("Error closing CLI: %v", err)
+		}
+	}()
+
+	// Get project details
+	project, err := cliInstance.App.ProjectService.GetProjectByID(ctx, projectID)
+	if err != nil {
+		fmt.Printf("Current project: %s (project not found)\n", currentProject)
+		return nil
+	}
+
+	fmt.Printf("Current project: %d (%s)\n", projectID, project.Name)
+	return nil
+}

--- a/internal/cli/use/use.go
+++ b/internal/cli/use/use.go
@@ -1,0 +1,32 @@
+// Package use holds all cli commands related to setting contextual information
+// e.g., paso use ...
+package use
+
+import (
+	"github.com/spf13/cobra"
+)
+
+// UseCmd returns the use parent command
+func UseCmd() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "use",
+		Short: "Manage contextual settings (project, ssh, etc.)",
+		Long: `Set and manage contextual information for the current shell session.
+
+The 'use' command allows you to set persistent context that applies to
+subsequent commands, eliminating the need to repeatedly specify flags.
+
+Available contexts:
+  - project: Set the current project context
+  - ssh: (future) Set SSH configuration context
+
+Examples:
+  eval $(paso use project 3)       # Use project 3
+  eval $(paso use project --clear) # Clear project context
+  paso use project --show          # Show current project`,
+	}
+
+	cmd.AddCommand(ProjectCmd())
+
+	return cmd
+}

--- a/main.go
+++ b/main.go
@@ -11,6 +11,7 @@ import (
 	"github.com/thenoetrevino/paso/internal/cli/setup"
 	"github.com/thenoetrevino/paso/internal/cli/task"
 	"github.com/thenoetrevino/paso/internal/cli/tutorial"
+	"github.com/thenoetrevino/paso/internal/cli/use"
 	"github.com/thenoetrevino/paso/internal/launcher"
 )
 
@@ -48,6 +49,7 @@ func init() {
 	rootCmd.AddCommand(project.ProjectCmd())
 	rootCmd.AddCommand(column.ColumnCmd())
 	rootCmd.AddCommand(label.LabelCmd())
+	rootCmd.AddCommand(use.UseCmd())
 	rootCmd.AddCommand(tutorial.TutorialCmd())
 	rootCmd.AddCommand(setup.SetupCmd())
 


### PR DESCRIPTION
Add 'paso use project' command to set project context via environment variables, eliminating need to pass --project flag on every command.

Implementation:
- Created internal/cli/use/ package with top-level 'use' command
- Added 'use project' subcommand for setting PASO_PROJECT env var
- Made --project flag optional across 8 commands with env fallback
- Added GetProjectID() helper with precedence: flag > env > error

Usage:
  eval $(paso use project 3)       # Set project context
  eval $(paso use project --clear) # Clear context
  paso use project --show          # Show current project

Benefits:
- Session-scoped (per-terminal, not global)
- Each terminal maintains independent context
- Backwards compatible (--project flag still works)
- Extensible for future contexts (ssh, etc.)

Modified commands to support optional --project:
- task create, list, ready, blocked
- column create, list
- label create, list