### PR TITLE
feat: add configurable ctrl+z suspend support

### DIFF
--- a/internal/config/keymaps.go
+++ b/internal/config/keymaps.go
@@ -47,6 +47,7 @@ type KeyMappings struct {
 	ConnectRemote string `yaml:"connect_remote"`
 	FilterBar     string `yaml:"filter_bar"`
 	Quit          string `yaml:"quit"`
+	Suspend       string `yaml:"suspend"`
 
 	// Views
 	ToggleView        string `yaml:"toggle_view"`
@@ -99,6 +100,7 @@ func DefaultKeyMappings() KeyMappings {
 		ConnectRemote: "ctrl+h",
 		FilterBar:     "ctrl+f",
 		Quit:          "q",
+		Suspend:       "ctrl+z",
 
 		// Views
 		ToggleView:        "v",
@@ -211,6 +213,9 @@ func (k *KeyMappings) applyDefaults() {
 	}
 	if k.Quit == "" {
 		k.Quit = defaults.Quit
+	}
+	if k.Suspend == "" {
+		k.Suspend = defaults.Suspend
 	}
 	if k.ToggleView == "" {
 		k.ToggleView = defaults.ToggleView

--- a/internal/tui/update.go
+++ b/internal/tui/update.go
@@ -309,6 +309,10 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 }
 
 func (m Model) handleKeyMsg(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
+	if msg.String() == m.Config.KeyMappings.Suspend {
+		return m, tea.Suspend
+	}
+
 	switch m.UIState.Mode {
 	case state.NormalMode:
 		return m.handleNormalMode(msg)

--- a/internal/tui/view_layers.go
+++ b/internal/tui/view_layers.go
@@ -354,6 +354,7 @@ VIEW
 
 OTHER
   %s     Show this help
+  %s     Suspend (resume with fg)
   %s     Quit
 
 Press any key to close`,
@@ -381,6 +382,7 @@ Press any key to close`,
 		km.ToggleView,
 		km.MoveTaskToProject,
 		km.ShowHelp,
+		km.Suspend,
 		km.Quit,
 	)
 }


### PR DESCRIPTION
Allow users to suspend paso with ctrl+z (like neovim) and resume with fg. The suspend key is handled globally so it works from any mode. Configurable via the suspend key mapping in config.yaml.

Closes #99

## Checklist
- [x] Read `CONTRIBUTING.md`
- [x] Ran tests (`go test ./... -race`) locally
- [x] Formatted and linted with `gofmt -w .` and `golangci-lint run ./...` respectively
- [x] Added tests if necessary (significant changes/complex logic)
- [x] Updated documentation if applicable
- [x] Updated `README.md` if applicable

## Summary
<!--
What does this PR change and/or fix? 
Examples:
Adds this feature with some basic tests. Remove this one thing due to this other thing
Closes: 54
Fixes: 67
-->
