### PR TITLE
fix: add per-message debounce to suppress spammy repeated notifications

### DIFF
--- a/internal/tui/model.go
+++ b/internal/tui/model.go
@@ -295,8 +295,12 @@ const notificationDuration = 1 * time.Second
 
 // addNotification adds a notification and returns a tea.Cmd that will fire
 // a NotificationExpiredMsg after the notification duration elapses.
+// Returns nil if the notification was suppressed by debouncing.
 func (m *Model) addNotification(level state.NotificationLevel, message string) tea.Cmd {
 	id := m.UI.Notification.Add(level, message)
+	if id == 0 {
+		return nil
+	}
 	return tea.Tick(notificationDuration, func(t time.Time) tea.Msg {
 		return NotificationExpiredMsg{ID: id}
 	})

--- a/internal/tui/state/notification_state.go
+++ b/internal/tui/state/notification_state.go
@@ -1,6 +1,9 @@
 package state
 
 import (
+	"fmt"
+	"time"
+
 	"charm.land/lipgloss/v2"
 )
 
@@ -18,6 +21,10 @@ const (
 
 const maxNotifications = 3
 
+// DefaultDebounceDuration is the default time window during which duplicate
+// notifications (same level + message) are suppressed.
+const DefaultDebounceDuration = 500 * time.Millisecond
+
 // Notification represents a single notification message with a severity level.
 type Notification struct {
 	ID      int
@@ -28,6 +35,9 @@ type Notification struct {
 // NotificationState manages notification display state.
 // This provides a centralized way to handle user-facing notifications
 // of different severity levels throughout the application.
+//
+// It includes per-message debouncing: if the same level+message is added
+// within the debounce window, the duplicate is suppressed (Add returns 0).
 type NotificationState struct {
 	// notifications contains the list of current notifications to display
 	notifications []Notification
@@ -37,25 +47,45 @@ type NotificationState struct {
 	windowWidth int
 	// windowHeight tracks the current window height for positioning
 	windowHeight int
+	// lastSeen tracks when each notification key (level:message) was last added,
+	// used for per-message debouncing to suppress rapid duplicate notifications.
+	lastSeen map[string]time.Time
+	// debounceDuration is the time window during which duplicate notifications are suppressed.
+	debounceDuration time.Duration
 }
 
 // NewNotificationState creates a new NotificationState with no notifications.
 func NewNotificationState() *NotificationState {
 	return &NotificationState{
-		notifications: []Notification{},
-		nextID:        1,
-		windowWidth:   0,
-		windowHeight:  0,
+		notifications:    []Notification{},
+		nextID:           1,
+		windowWidth:      0,
+		windowHeight:     0,
+		lastSeen:         make(map[string]time.Time),
+		debounceDuration: DefaultDebounceDuration,
 	}
 }
 
 // Add adds a new notification with the specified level and message.
-// Returns the ID assigned to the new notification.
+// Returns the ID assigned to the new notification, or 0 if the notification
+// was suppressed by debouncing (same level+message added within the debounce window).
 //
 // Parameters:
 //   - level: the severity level of the notification
 //   - message: the notification message to display
 func (s *NotificationState) Add(level NotificationLevel, message string) int {
+	now := time.Now()
+	key := fmt.Sprintf("%d:%s", level, message)
+
+	// Debounce: suppress if the same notification was added recently
+	if lastTime, ok := s.lastSeen[key]; ok {
+		if now.Sub(lastTime) < s.debounceDuration {
+			return 0
+		}
+	}
+
+	s.lastSeen[key] = now
+
 	id := s.nextID
 	s.notifications = append(s.notifications, Notification{
 		ID:      id,
@@ -73,7 +103,11 @@ func (s *NotificationState) Add(level NotificationLevel, message string) int {
 }
 
 // Remove removes a notification by its ID. Used for auto-dismiss expiration.
+// ID 0 is a no-op (0 is the sentinel for debounce-suppressed notifications).
 func (s *NotificationState) Remove(id int) {
+	if id == 0 {
+		return
+	}
 	for i, n := range s.notifications {
 		if n.ID == id {
 			s.notifications = append(s.notifications[:i], s.notifications[i+1:]...)

--- a/internal/tui/state/notification_state_test.go
+++ b/internal/tui/state/notification_state_test.go
@@ -1,0 +1,99 @@
+package state
+
+import (
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestAdd_BasicNotification(t *testing.T) {
+	t.Parallel()
+	ns := NewNotificationState()
+
+	id := ns.Add(LevelInfo, "Hello")
+
+	assert.NotEqual(t, 0, id, "Add should return a non-zero ID")
+	require.Len(t, ns.All(), 1)
+	assert.Equal(t, "Hello", ns.All()[0].Message)
+	assert.Equal(t, LevelInfo, ns.All()[0].Level)
+}
+
+func TestAdd_DebounceSameMessage(t *testing.T) {
+	t.Parallel()
+	ns := NewNotificationState()
+
+	id1 := ns.Add(LevelInfo, "Already at the last column")
+	id2 := ns.Add(LevelInfo, "Already at the last column")
+
+	assert.NotEqual(t, 0, id1, "first add should succeed")
+	assert.Equal(t, 0, id2, "duplicate within debounce window should be suppressed")
+	assert.Len(t, ns.All(), 1, "only one notification should exist")
+}
+
+func TestAdd_DifferentMessagesNotDebounced(t *testing.T) {
+	t.Parallel()
+	ns := NewNotificationState()
+
+	id1 := ns.Add(LevelInfo, "Already at the last column")
+	id2 := ns.Add(LevelInfo, "Already at the first task")
+
+	assert.NotEqual(t, 0, id1)
+	assert.NotEqual(t, 0, id2)
+	assert.Len(t, ns.All(), 2, "different messages should both be added")
+}
+
+func TestAdd_DifferentLevelsSameMessage(t *testing.T) {
+	t.Parallel()
+	ns := NewNotificationState()
+
+	id1 := ns.Add(LevelInfo, "No task selected")
+	id2 := ns.Add(LevelError, "No task selected")
+
+	assert.NotEqual(t, 0, id1)
+	assert.NotEqual(t, 0, id2)
+	assert.Len(t, ns.All(), 2, "same message at different levels should both be added")
+}
+
+func TestAdd_DebounceExpiresAfterDuration(t *testing.T) {
+	t.Parallel()
+	ns := NewNotificationState()
+	ns.debounceDuration = 1 * time.Millisecond
+
+	id1 := ns.Add(LevelInfo, "Already at the last column")
+	assert.NotEqual(t, 0, id1)
+
+	time.Sleep(2 * time.Millisecond)
+
+	id2 := ns.Add(LevelInfo, "Already at the last column")
+	assert.NotEqual(t, 0, id2, "should succeed after debounce window expires")
+	assert.Len(t, ns.All(), 2)
+}
+
+func TestAdd_MaxNotificationsEvictionStillWorks(t *testing.T) {
+	t.Parallel()
+	ns := NewNotificationState()
+
+	ns.Add(LevelInfo, "msg 1")
+	ns.Add(LevelInfo, "msg 2")
+	ns.Add(LevelInfo, "msg 3")
+	ns.Add(LevelInfo, "msg 4")
+
+	assert.Len(t, ns.All(), maxNotifications, "should evict oldest when exceeding max")
+	assert.Equal(t, "msg 2", ns.All()[0].Message, "oldest should be evicted")
+	assert.Equal(t, "msg 4", ns.All()[2].Message, "newest should be last")
+}
+
+func TestRemove_ZeroIDNoOp(t *testing.T) {
+	t.Parallel()
+	ns := NewNotificationState()
+
+	ns.Add(LevelInfo, "keep me")
+
+	// Remove with ID 0 (suppressed sentinel) should not panic or remove anything
+	ns.Remove(0)
+
+	assert.Len(t, ns.All(), 1, "Remove(0) should be a no-op")
+	assert.Equal(t, "keep me", ns.All()[0].Message)
+}


### PR DESCRIPTION
When holding a navigation key at a boundary (e.g., right arrow at the last column), the same notification would fire on every keypress. This adds a 500ms debounce window keyed by level+message to NotificationState.Add(), so duplicate notifications are suppressed while different notification types still display normally.

https://claude.ai/code/session_01VvYN4LK94mdgoGsLezd7i8

## Checklist
- [x] Read `CONTRIBUTING.md`
- [x] Ran tests (`go test ./... -race`) locally
- [x] Formatted and linted with `gofmt -w .` and `golangci-lint run ./...` respectively
- [x] Added tests if necessary (significant changes/complex logic)
- [x] Updated documentation if applicable
- [x] Updated `README.md` if applicable

## Summary
<!--
What does this PR change and/or fix? 
Examples:
Closes: 54
Fixes: 67
-->
Closes: #106 