### PR TITLE
feat: restructure KeyMappings into nested config with form-specific k…

### DIFF
--- a/README.md
+++ b/README.md
@@ -115,17 +115,9 @@ You can also override individual colors or point to an external theme file with 
 
 ### Keybindings
 
-All TUI keys are remappable. For example:
+All TUI keys are remappable. 
 
-```yaml
-key_mappings:
-  add_task: "a"
-  edit_task: "e"
-  delete_task: "d"
-  prev_column: "h"
-  next_column: "l"
-  show_help: "?"
-```
+See [`example_config.yaml`](example_config.yaml) for every available option with defaults.
 
 ### Database Connections
 

--- a/example_config.yaml
+++ b/example_config.yaml
@@ -1,0 +1,93 @@
+# Paso Configuration
+# Copy this file to ~/.config/paso/config.yaml
+# All fields are optional — unset values use the defaults shown below.
+
+# Theme preset: default, monochrome, wave, dragon, lotus
+theme:
+  preset: default
+
+# Key mappings — organized by context.
+# Only override the keys you want to change; the rest keep their defaults.
+key_mappings:
+
+  # Navigation keys for moving around the UI
+  navigation:
+    move_left: "h"
+    move_right: "l"
+    move_up: "k"
+    move_down: "j"
+    scroll_viewport_left: "["
+    scroll_viewport_right: "]"
+    next_project: "}"
+    prev_project: "{"
+
+  # Task actions in normal mode (single-key shortcuts)
+  tasks:
+    add_task: "a"
+    edit_task: "e"
+    delete_task: "d"
+    view_task: " "              # space
+    edit_labels: "ctrl+l"
+    edit_priority: "ctrl+r"
+    edit_assignee: "ctrl+a"
+    edit_estimate: "ctrl+e"
+    edit_due_date: "ctrl+d"
+    edit_parent_task: "p"
+    edit_child_task: "c"
+    edit_type: "ctrl+t"
+    move_task_to_project: "s"
+
+  # Kanban board actions (uppercase = Shift held)
+  kanban:
+    create_column: "C"
+    rename_column: "R"
+    delete_column: "X"
+    move_task_left: "H"
+    move_task_right: "L"
+    move_task_up: "K"
+    move_task_down: "J"
+
+  # Project management
+  projects:
+    create_project: "P"
+    edit_project: "E"
+    delete_project: "D"
+
+  # Form shortcuts (ctrl+ modifiers so they don't conflict with text input)
+  forms:
+    save_form: "ctrl+s"
+    open_comments_view: "ctrl+n"
+    refresh_git_data: "f5"
+    edit_labels: "ctrl+l"
+    edit_parent_task: "ctrl+p"
+    edit_child_task: "ctrl+c"
+    edit_priority: "ctrl+r"
+    edit_type: "ctrl+t"
+    edit_assignee: "ctrl+a"
+    edit_estimate: "ctrl+e"
+    edit_due_date: "ctrl+d"
+    show_help: "ctrl+/"
+
+  # Picker overlay shortcuts
+  pickers:
+    delete_label: "ctrl+d"
+
+  # Global shortcuts
+  general:
+    show_help: "?"
+    connect_remote: "ctrl+h"
+    filter_bar: "ctrl+f"
+    quit: "q"
+    suspend: "ctrl+z"
+    toggle_view: "v"
+    search: "/"
+
+# Database connections (managed via `paso db` commands)
+# databases:
+#   - name: local
+#     connection_string: "~/.local/share/paso/tasks.db"
+#     type: sqlite
+#   - name: remote
+#     connection_string: "postgres://user:pass@host/db"
+#     type: postgres
+# active_database: local

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -12,10 +12,26 @@ import (
 func TestDefaultKeyMappings(t *testing.T) {
 	defaults := DefaultKeyMappings()
 
-	// Test a few key bindings
-	assert.Equal(t, "q", defaults.Quit)
-	assert.Equal(t, "a", defaults.AddTask)
-	assert.Equal(t, " ", defaults.ViewTask)
+	assert.Equal(t, "q", defaults.General.Quit)
+	assert.Equal(t, "a", defaults.Tasks.AddTask)
+	assert.Equal(t, " ", defaults.Tasks.ViewTask)
+	assert.Equal(t, "j", defaults.Navigation.MoveDown)
+	assert.Equal(t, "C", defaults.Kanban.CreateColumn)
+	assert.Equal(t, "P", defaults.Projects.CreateProject)
+	assert.Equal(t, "ctrl+s", defaults.Forms.SaveForm)
+	assert.Equal(t, "ctrl+d", defaults.Pickers.DeleteLabel)
+	assert.Equal(t, "/", defaults.General.Search)
+	assert.Equal(t, "ctrl+t", defaults.Tasks.EditType)
+	assert.Equal(t, "ctrl+n", defaults.Forms.OpenCommentsView)
+	assert.Equal(t, "f5", defaults.Forms.RefreshGitData)
+	assert.Equal(t, "ctrl+l", defaults.Forms.EditLabels)
+	assert.Equal(t, "ctrl+p", defaults.Forms.EditParentTask)
+	assert.Equal(t, "ctrl+c", defaults.Forms.EditChildTask)
+	assert.Equal(t, "ctrl+r", defaults.Forms.EditPriority)
+	assert.Equal(t, "ctrl+a", defaults.Forms.EditAssignee)
+	assert.Equal(t, "ctrl+e", defaults.Forms.EditEstimate)
+	assert.Equal(t, "ctrl+d", defaults.Forms.EditDueDate)
+	assert.Equal(t, "ctrl+/", defaults.Forms.ShowHelp)
 }
 
 func TestLoadConfigWithoutFile(t *testing.T) {
@@ -26,7 +42,7 @@ func TestLoadConfigWithoutFile(t *testing.T) {
 	require.NoError(t, err)
 
 	// Should return default config
-	assert.Equal(t, "q", cfg.KeyMappings.Quit)
+	assert.Equal(t, "q", cfg.KeyMappings.General.Quit)
 }
 
 func TestLoadConfigWithFile(t *testing.T) {
@@ -37,11 +53,13 @@ func TestLoadConfigWithFile(t *testing.T) {
 	configDir := filepath.Join(tempDir, "paso")
 	require.NoError(t, os.MkdirAll(configDir, 0755))
 
-	// Write custom config
+	// Write custom config with nested structure
 	configContent := `key_mappings:
-  quit: "x"
-  add_task: "n"
-  view_task: "v"
+  general:
+    quit: "x"
+  tasks:
+    add_task: "n"
+    view_task: "v"
 `
 	configPath := filepath.Join(configDir, "config.yaml")
 	require.NoError(t, os.WriteFile(configPath, []byte(configContent), 0644))
@@ -50,12 +68,17 @@ func TestLoadConfigWithFile(t *testing.T) {
 	require.NoError(t, err)
 
 	// Should load custom values
-	assert.Equal(t, "x", cfg.KeyMappings.Quit)
-	assert.Equal(t, "n", cfg.KeyMappings.AddTask)
-	assert.Equal(t, "v", cfg.KeyMappings.ViewTask)
+	assert.Equal(t, "x", cfg.KeyMappings.General.Quit)
+	assert.Equal(t, "n", cfg.KeyMappings.Tasks.AddTask)
+	assert.Equal(t, "v", cfg.KeyMappings.Tasks.ViewTask)
 
 	// Unspecified values should use defaults
-	assert.Equal(t, "e", cfg.KeyMappings.EditTask)
+	assert.Equal(t, "e", cfg.KeyMappings.Tasks.EditTask)
+	assert.Equal(t, "j", cfg.KeyMappings.Navigation.MoveDown)
+	assert.Equal(t, "C", cfg.KeyMappings.Kanban.CreateColumn)
+	assert.Equal(t, "P", cfg.KeyMappings.Projects.CreateProject)
+	assert.Equal(t, "ctrl+s", cfg.KeyMappings.Forms.SaveForm)
+	assert.Equal(t, "ctrl+d", cfg.KeyMappings.Pickers.DeleteLabel)
 }
 
 func TestSaveConfig(t *testing.T) {
@@ -65,9 +88,13 @@ func TestSaveConfig(t *testing.T) {
 
 	cfg := &Config{
 		KeyMappings: KeyMappings{
-			Quit:     "x",
-			AddTask:  "n",
-			ViewTask: "v",
+			General: GeneralKeys{
+				Quit: "x",
+			},
+			Tasks: TaskKeys{
+				AddTask:  "n",
+				ViewTask: "v",
+			},
 		},
 	}
 
@@ -87,6 +114,6 @@ func TestSaveConfig(t *testing.T) {
 	require.NoError(t, err)
 
 	// Verify values match
-	assert.Equal(t, "x", cfg2.KeyMappings.Quit)
-	assert.Equal(t, "n", cfg2.KeyMappings.AddTask)
+	assert.Equal(t, "x", cfg2.KeyMappings.General.Quit)
+	assert.Equal(t, "n", cfg2.KeyMappings.Tasks.AddTask)
 }

--- a/internal/config/keymaps.go
+++ b/internal/config/keymaps.go
@@ -162,8 +162,7 @@ func DefaultKeyMappings() KeyMappings {
 	}
 }
 
-func (n *NavigationKeys) applyDefaults() {
-	defaults := DefaultKeyMappings().Navigation
+func (n *NavigationKeys) applyDefaultsFrom(defaults NavigationKeys) {
 	if n.MoveLeft == "" {
 		n.MoveLeft = defaults.MoveLeft
 	}
@@ -190,8 +189,7 @@ func (n *NavigationKeys) applyDefaults() {
 	}
 }
 
-func (t *TaskKeys) applyDefaults() {
-	defaults := DefaultKeyMappings().Tasks
+func (t *TaskKeys) applyDefaultsFrom(defaults TaskKeys) {
 	if t.AddTask == "" {
 		t.AddTask = defaults.AddTask
 	}
@@ -233,8 +231,7 @@ func (t *TaskKeys) applyDefaults() {
 	}
 }
 
-func (k *KanbanKeys) applyDefaults() {
-	defaults := DefaultKeyMappings().Kanban
+func (k *KanbanKeys) applyDefaultsFrom(defaults KanbanKeys) {
 	if k.CreateColumn == "" {
 		k.CreateColumn = defaults.CreateColumn
 	}
@@ -258,8 +255,7 @@ func (k *KanbanKeys) applyDefaults() {
 	}
 }
 
-func (p *ProjectKeys) applyDefaults() {
-	defaults := DefaultKeyMappings().Projects
+func (p *ProjectKeys) applyDefaultsFrom(defaults ProjectKeys) {
 	if p.CreateProject == "" {
 		p.CreateProject = defaults.CreateProject
 	}
@@ -271,8 +267,7 @@ func (p *ProjectKeys) applyDefaults() {
 	}
 }
 
-func (f *FormKeys) applyDefaults() {
-	defaults := DefaultKeyMappings().Forms
+func (f *FormKeys) applyDefaultsFrom(defaults FormKeys) {
 	if f.SaveForm == "" {
 		f.SaveForm = defaults.SaveForm
 	}
@@ -311,15 +306,13 @@ func (f *FormKeys) applyDefaults() {
 	}
 }
 
-func (p *PickerKeys) applyDefaults() {
-	defaults := DefaultKeyMappings().Pickers
+func (p *PickerKeys) applyDefaultsFrom(defaults PickerKeys) {
 	if p.DeleteLabel == "" {
 		p.DeleteLabel = defaults.DeleteLabel
 	}
 }
 
-func (g *GeneralKeys) applyDefaults() {
-	defaults := DefaultKeyMappings().General
+func (g *GeneralKeys) applyDefaultsFrom(defaults GeneralKeys) {
 	if g.ShowHelp == "" {
 		g.ShowHelp = defaults.ShowHelp
 	}
@@ -345,11 +338,12 @@ func (g *GeneralKeys) applyDefaults() {
 
 // applyDefaults fills in missing key mappings with defaults.
 func (k *KeyMappings) applyDefaults() {
-	k.Navigation.applyDefaults()
-	k.Tasks.applyDefaults()
-	k.Kanban.applyDefaults()
-	k.Projects.applyDefaults()
-	k.Forms.applyDefaults()
-	k.Pickers.applyDefaults()
-	k.General.applyDefaults()
+	d := DefaultKeyMappings()
+	k.Navigation.applyDefaultsFrom(d.Navigation)
+	k.Tasks.applyDefaultsFrom(d.Tasks)
+	k.Kanban.applyDefaultsFrom(d.Kanban)
+	k.Projects.applyDefaultsFrom(d.Projects)
+	k.Forms.applyDefaultsFrom(d.Forms)
+	k.Pickers.applyDefaultsFrom(d.Pickers)
+	k.General.applyDefaultsFrom(d.General)
 }

--- a/internal/config/keymaps.go
+++ b/internal/config/keymaps.go
@@ -1,125 +1,248 @@
 package config
 
-// KeyMappings defines all configurable key bindings
+// KeyMappings defines all configurable key bindings, organized by context.
 type KeyMappings struct {
-	// Tasks
-	AddTask        string `yaml:"add_task"`
-	EditTask       string `yaml:"edit_task"`
-	DeleteTask     string `yaml:"delete_task"`
-	MoveTaskLeft   string `yaml:"move_task_left"`
-	MoveTaskRight  string `yaml:"move_task_right"`
-	MoveTaskUp     string `yaml:"move_task_up"`
-	MoveTaskDown   string `yaml:"move_task_down"`
-	ViewTask       string `yaml:"view_task"`
-	EditLabels     string `yaml:"edit_labels"`
-	EditPriority   string `yaml:"edit_priority"`
-	EditAssignee   string `yaml:"edit_assignee"`
-	EditEstimate   string `yaml:"edit_estimate"`
-	EditDueDate    string `yaml:"edit_due_date"`
-	EditParentTask string `yaml:"edit_parent_task"`
-	EditChildTask  string `yaml:"edit_child_task"`
+	Navigation NavigationKeys `yaml:"navigation"`
+	Tasks      TaskKeys       `yaml:"tasks"`
+	Kanban     KanbanKeys     `yaml:"kanban"`
+	Projects   ProjectKeys    `yaml:"projects"`
+	Forms      FormKeys       `yaml:"forms"`
+	Pickers    PickerKeys     `yaml:"pickers"`
+	General    GeneralKeys    `yaml:"general"`
+}
 
-	// Forms
-	SaveForm string `yaml:"save_form"`
-
-	// Columns
-	CreateColumn string `yaml:"create_column"`
-	RenameColumn string `yaml:"rename_column"`
-	DeleteColumn string `yaml:"delete_column"`
-
-	// Projects
-	CreateProject string `yaml:"create_project"`
-	EditProject   string `yaml:"edit_project"`
-	DeleteProject string `yaml:"delete_project"`
-
-	// Navigation
-	PrevColumn          string `yaml:"prev_column"`
-	NextColumn          string `yaml:"next_column"`
-	PrevTask            string `yaml:"prev_task"`
-	NextTask            string `yaml:"next_task"`
+// NavigationKeys defines keybindings for moving around the UI.
+type NavigationKeys struct {
+	MoveLeft            string `yaml:"move_left"`
+	MoveRight           string `yaml:"move_right"`
+	MoveUp              string `yaml:"move_up"`
+	MoveDown            string `yaml:"move_down"`
 	ScrollViewportLeft  string `yaml:"scroll_viewport_left"`
 	ScrollViewportRight string `yaml:"scroll_viewport_right"`
 	NextProject         string `yaml:"next_project"`
 	PrevProject         string `yaml:"prev_project"`
+}
 
-	// Other
+// TaskKeys defines keybindings for task actions.
+type TaskKeys struct {
+	AddTask           string `yaml:"add_task"`
+	EditTask          string `yaml:"edit_task"`
+	DeleteTask        string `yaml:"delete_task"`
+	ViewTask          string `yaml:"view_task"`
+	EditLabels        string `yaml:"edit_labels"`
+	EditPriority      string `yaml:"edit_priority"`
+	EditAssignee      string `yaml:"edit_assignee"`
+	EditEstimate      string `yaml:"edit_estimate"`
+	EditDueDate       string `yaml:"edit_due_date"`
+	EditParentTask    string `yaml:"edit_parent_task"`
+	EditChildTask     string `yaml:"edit_child_task"`
+	EditType          string `yaml:"edit_type"`
+	MoveTaskToProject string `yaml:"move_task_to_project"`
+}
+
+// KanbanKeys defines keybindings specific to the kanban board view.
+type KanbanKeys struct {
+	CreateColumn  string `yaml:"create_column"`
+	RenameColumn  string `yaml:"rename_column"`
+	DeleteColumn  string `yaml:"delete_column"`
+	MoveTaskLeft  string `yaml:"move_task_left"`
+	MoveTaskRight string `yaml:"move_task_right"`
+	MoveTaskUp    string `yaml:"move_task_up"`
+	MoveTaskDown  string `yaml:"move_task_down"`
+}
+
+// ProjectKeys defines keybindings for project management.
+type ProjectKeys struct {
+	CreateProject string `yaml:"create_project"`
+	EditProject   string `yaml:"edit_project"`
+	DeleteProject string `yaml:"delete_project"`
+}
+
+// FormKeys defines keybindings used within form contexts.
+// These use ctrl+ modifiers to avoid conflicting with text input.
+type FormKeys struct {
+	SaveForm         string `yaml:"save_form"`
+	OpenCommentsView string `yaml:"open_comments_view"`
+	RefreshGitData   string `yaml:"refresh_git_data"`
+	EditLabels       string `yaml:"edit_labels"`
+	EditParentTask   string `yaml:"edit_parent_task"`
+	EditChildTask    string `yaml:"edit_child_task"`
+	EditPriority     string `yaml:"edit_priority"`
+	EditType         string `yaml:"edit_type"`
+	EditAssignee     string `yaml:"edit_assignee"`
+	EditEstimate     string `yaml:"edit_estimate"`
+	EditDueDate      string `yaml:"edit_due_date"`
+	ShowHelp         string `yaml:"show_help"`
+}
+
+// PickerKeys defines keybindings used within picker overlays.
+type PickerKeys struct {
+	DeleteLabel string `yaml:"delete_label"`
+}
+
+// GeneralKeys defines global keybindings.
+type GeneralKeys struct {
 	ShowHelp      string `yaml:"show_help"`
 	ConnectRemote string `yaml:"connect_remote"`
 	FilterBar     string `yaml:"filter_bar"`
 	Quit          string `yaml:"quit"`
 	Suspend       string `yaml:"suspend"`
-
-	// Views
-	ToggleView        string `yaml:"toggle_view"`
-	MoveTaskToProject string `yaml:"move_task_to_project"`
+	ToggleView    string `yaml:"toggle_view"`
+	Search        string `yaml:"search"`
 }
 
-// DefaultKeyMappings returns the default key mappings
+// DefaultKeyMappings returns the default key mappings.
 func DefaultKeyMappings() KeyMappings {
 	return KeyMappings{
-		// Tasks
-		AddTask:        "a",
-		EditTask:       "e",
-		DeleteTask:     "d",
-		MoveTaskLeft:   "H",
-		MoveTaskRight:  "L",
-		MoveTaskUp:     "K",
-		MoveTaskDown:   "J",
-		ViewTask:       " ",
-		EditLabels:     "ctrl+l",
-		EditPriority:   "ctrl+r",
-		EditAssignee:   "ctrl+a",
-		EditEstimate:   "ctrl+e",
-		EditDueDate:    "ctrl+d",
-		EditParentTask: "p",
-		EditChildTask:  "c",
-		SaveForm:       "ctrl+s",
-
-		// Columns
-		CreateColumn: "C",
-		RenameColumn: "R",
-		DeleteColumn: "X",
-
-		// Projects
-		CreateProject: "P",
-		EditProject:   "E",
-		DeleteProject: "D",
-
-		// Navigation
-		PrevColumn:          "h",
-		NextColumn:          "l",
-		PrevTask:            "k",
-		NextTask:            "j",
-		ScrollViewportLeft:  "[",
-		ScrollViewportRight: "]",
-		NextProject:         "}",
-		PrevProject:         "{",
-
-		// Other
-		ShowHelp:      "?",
-		ConnectRemote: "ctrl+h",
-		FilterBar:     "ctrl+f",
-		Quit:          "q",
-		Suspend:       "ctrl+z",
-
-		// Views
-		ToggleView:        "v",
-		MoveTaskToProject: "s",
+		Navigation: NavigationKeys{
+			MoveLeft:            "h",
+			MoveRight:           "l",
+			MoveUp:              "k",
+			MoveDown:            "j",
+			ScrollViewportLeft:  "[",
+			ScrollViewportRight: "]",
+			NextProject:         "}",
+			PrevProject:         "{",
+		},
+		Tasks: TaskKeys{
+			AddTask:           "a",
+			EditTask:          "e",
+			DeleteTask:        "d",
+			ViewTask:          " ",
+			EditLabels:        "ctrl+l",
+			EditPriority:      "ctrl+r",
+			EditAssignee:      "ctrl+a",
+			EditEstimate:      "ctrl+e",
+			EditDueDate:       "ctrl+d",
+			EditParentTask:    "p",
+			EditChildTask:     "c",
+			EditType:          "ctrl+t",
+			MoveTaskToProject: "s",
+		},
+		Kanban: KanbanKeys{
+			CreateColumn:  "C",
+			RenameColumn:  "R",
+			DeleteColumn:  "X",
+			MoveTaskLeft:  "H",
+			MoveTaskRight: "L",
+			MoveTaskUp:    "K",
+			MoveTaskDown:  "J",
+		},
+		Projects: ProjectKeys{
+			CreateProject: "P",
+			EditProject:   "E",
+			DeleteProject: "D",
+		},
+		Forms: FormKeys{
+			SaveForm:         "ctrl+s",
+			OpenCommentsView: "ctrl+n",
+			RefreshGitData:   "f5",
+			EditLabels:       "ctrl+l",
+			EditParentTask:   "ctrl+p",
+			EditChildTask:    "ctrl+c",
+			EditPriority:     "ctrl+r",
+			EditType:         "ctrl+t",
+			EditAssignee:     "ctrl+a",
+			EditEstimate:     "ctrl+e",
+			EditDueDate:      "ctrl+d",
+			ShowHelp:         "ctrl+/",
+		},
+		Pickers: PickerKeys{
+			DeleteLabel: "ctrl+d",
+		},
+		General: GeneralKeys{
+			ShowHelp:      "?",
+			ConnectRemote: "ctrl+h",
+			FilterBar:     "ctrl+f",
+			Quit:          "q",
+			Suspend:       "ctrl+z",
+			ToggleView:    "v",
+			Search:        "/",
+		},
 	}
 }
 
-// applyDefaults fills in missing key mappings with defaults
-func (k *KeyMappings) applyDefaults() {
-	defaults := DefaultKeyMappings()
+func (n *NavigationKeys) applyDefaults() {
+	defaults := DefaultKeyMappings().Navigation
+	if n.MoveLeft == "" {
+		n.MoveLeft = defaults.MoveLeft
+	}
+	if n.MoveRight == "" {
+		n.MoveRight = defaults.MoveRight
+	}
+	if n.MoveUp == "" {
+		n.MoveUp = defaults.MoveUp
+	}
+	if n.MoveDown == "" {
+		n.MoveDown = defaults.MoveDown
+	}
+	if n.ScrollViewportLeft == "" {
+		n.ScrollViewportLeft = defaults.ScrollViewportLeft
+	}
+	if n.ScrollViewportRight == "" {
+		n.ScrollViewportRight = defaults.ScrollViewportRight
+	}
+	if n.NextProject == "" {
+		n.NextProject = defaults.NextProject
+	}
+	if n.PrevProject == "" {
+		n.PrevProject = defaults.PrevProject
+	}
+}
 
-	if k.AddTask == "" {
-		k.AddTask = defaults.AddTask
+func (t *TaskKeys) applyDefaults() {
+	defaults := DefaultKeyMappings().Tasks
+	if t.AddTask == "" {
+		t.AddTask = defaults.AddTask
 	}
-	if k.EditTask == "" {
-		k.EditTask = defaults.EditTask
+	if t.EditTask == "" {
+		t.EditTask = defaults.EditTask
 	}
-	if k.DeleteTask == "" {
-		k.DeleteTask = defaults.DeleteTask
+	if t.DeleteTask == "" {
+		t.DeleteTask = defaults.DeleteTask
+	}
+	if t.ViewTask == "" {
+		t.ViewTask = defaults.ViewTask
+	}
+	if t.EditLabels == "" {
+		t.EditLabels = defaults.EditLabels
+	}
+	if t.EditPriority == "" {
+		t.EditPriority = defaults.EditPriority
+	}
+	if t.EditAssignee == "" {
+		t.EditAssignee = defaults.EditAssignee
+	}
+	if t.EditEstimate == "" {
+		t.EditEstimate = defaults.EditEstimate
+	}
+	if t.EditDueDate == "" {
+		t.EditDueDate = defaults.EditDueDate
+	}
+	if t.EditParentTask == "" {
+		t.EditParentTask = defaults.EditParentTask
+	}
+	if t.EditChildTask == "" {
+		t.EditChildTask = defaults.EditChildTask
+	}
+	if t.EditType == "" {
+		t.EditType = defaults.EditType
+	}
+	if t.MoveTaskToProject == "" {
+		t.MoveTaskToProject = defaults.MoveTaskToProject
+	}
+}
+
+func (k *KanbanKeys) applyDefaults() {
+	defaults := DefaultKeyMappings().Kanban
+	if k.CreateColumn == "" {
+		k.CreateColumn = defaults.CreateColumn
+	}
+	if k.RenameColumn == "" {
+		k.RenameColumn = defaults.RenameColumn
+	}
+	if k.DeleteColumn == "" {
+		k.DeleteColumn = defaults.DeleteColumn
 	}
 	if k.MoveTaskLeft == "" {
 		k.MoveTaskLeft = defaults.MoveTaskLeft
@@ -133,94 +256,100 @@ func (k *KeyMappings) applyDefaults() {
 	if k.MoveTaskDown == "" {
 		k.MoveTaskDown = defaults.MoveTaskDown
 	}
-	if k.ViewTask == "" {
-		k.ViewTask = defaults.ViewTask
+}
+
+func (p *ProjectKeys) applyDefaults() {
+	defaults := DefaultKeyMappings().Projects
+	if p.CreateProject == "" {
+		p.CreateProject = defaults.CreateProject
 	}
-	if k.EditLabels == "" {
-		k.EditLabels = defaults.EditLabels
+	if p.EditProject == "" {
+		p.EditProject = defaults.EditProject
 	}
-	if k.EditPriority == "" {
-		k.EditPriority = defaults.EditPriority
+	if p.DeleteProject == "" {
+		p.DeleteProject = defaults.DeleteProject
 	}
-	if k.EditAssignee == "" {
-		k.EditAssignee = defaults.EditAssignee
+}
+
+func (f *FormKeys) applyDefaults() {
+	defaults := DefaultKeyMappings().Forms
+	if f.SaveForm == "" {
+		f.SaveForm = defaults.SaveForm
 	}
-	if k.EditEstimate == "" {
-		k.EditEstimate = defaults.EditEstimate
+	if f.OpenCommentsView == "" {
+		f.OpenCommentsView = defaults.OpenCommentsView
 	}
-	if k.EditDueDate == "" {
-		k.EditDueDate = defaults.EditDueDate
+	if f.RefreshGitData == "" {
+		f.RefreshGitData = defaults.RefreshGitData
 	}
-	if k.EditParentTask == "" {
-		k.EditParentTask = defaults.EditParentTask
+	if f.EditLabels == "" {
+		f.EditLabels = defaults.EditLabels
 	}
-	if k.EditChildTask == "" {
-		k.EditChildTask = defaults.EditChildTask
+	if f.EditParentTask == "" {
+		f.EditParentTask = defaults.EditParentTask
 	}
-	if k.SaveForm == "" {
-		k.SaveForm = defaults.SaveForm
+	if f.EditChildTask == "" {
+		f.EditChildTask = defaults.EditChildTask
 	}
-	if k.CreateColumn == "" {
-		k.CreateColumn = defaults.CreateColumn
+	if f.EditPriority == "" {
+		f.EditPriority = defaults.EditPriority
 	}
-	if k.RenameColumn == "" {
-		k.RenameColumn = defaults.RenameColumn
+	if f.EditType == "" {
+		f.EditType = defaults.EditType
 	}
-	if k.DeleteColumn == "" {
-		k.DeleteColumn = defaults.DeleteColumn
+	if f.EditAssignee == "" {
+		f.EditAssignee = defaults.EditAssignee
 	}
-	if k.CreateProject == "" {
-		k.CreateProject = defaults.CreateProject
+	if f.EditEstimate == "" {
+		f.EditEstimate = defaults.EditEstimate
 	}
-	if k.EditProject == "" {
-		k.EditProject = defaults.EditProject
+	if f.EditDueDate == "" {
+		f.EditDueDate = defaults.EditDueDate
 	}
-	if k.DeleteProject == "" {
-		k.DeleteProject = defaults.DeleteProject
+	if f.ShowHelp == "" {
+		f.ShowHelp = defaults.ShowHelp
 	}
-	if k.PrevColumn == "" {
-		k.PrevColumn = defaults.PrevColumn
+}
+
+func (p *PickerKeys) applyDefaults() {
+	defaults := DefaultKeyMappings().Pickers
+	if p.DeleteLabel == "" {
+		p.DeleteLabel = defaults.DeleteLabel
 	}
-	if k.NextColumn == "" {
-		k.NextColumn = defaults.NextColumn
+}
+
+func (g *GeneralKeys) applyDefaults() {
+	defaults := DefaultKeyMappings().General
+	if g.ShowHelp == "" {
+		g.ShowHelp = defaults.ShowHelp
 	}
-	if k.PrevTask == "" {
-		k.PrevTask = defaults.PrevTask
+	if g.ConnectRemote == "" {
+		g.ConnectRemote = defaults.ConnectRemote
 	}
-	if k.NextTask == "" {
-		k.NextTask = defaults.NextTask
+	if g.FilterBar == "" {
+		g.FilterBar = defaults.FilterBar
 	}
-	if k.ScrollViewportLeft == "" {
-		k.ScrollViewportLeft = defaults.ScrollViewportLeft
+	if g.Quit == "" {
+		g.Quit = defaults.Quit
 	}
-	if k.ScrollViewportRight == "" {
-		k.ScrollViewportRight = defaults.ScrollViewportRight
+	if g.Suspend == "" {
+		g.Suspend = defaults.Suspend
 	}
-	if k.NextProject == "" {
-		k.NextProject = defaults.NextProject
+	if g.ToggleView == "" {
+		g.ToggleView = defaults.ToggleView
 	}
-	if k.PrevProject == "" {
-		k.PrevProject = defaults.PrevProject
+	if g.Search == "" {
+		g.Search = defaults.Search
 	}
-	if k.ShowHelp == "" {
-		k.ShowHelp = defaults.ShowHelp
-	}
-	if k.ConnectRemote == "" {
-		k.ConnectRemote = defaults.ConnectRemote
-	}
-	if k.FilterBar == "" {
-		k.FilterBar = defaults.FilterBar
-	}
-	if k.Quit == "" {
-		k.Quit = defaults.Quit
-	}
-	if k.Suspend == "" {
-		k.Suspend = defaults.Suspend
-	}
-	if k.ToggleView == "" {
-		k.ToggleView = defaults.ToggleView
-	}
-	if k.MoveTaskToProject == "" {
-		k.MoveTaskToProject = defaults.MoveTaskToProject
-	}
+}
+
+// applyDefaults fills in missing key mappings with defaults.
+func (k *KeyMappings) applyDefaults() {
+	k.Navigation.applyDefaults()
+	k.Tasks.applyDefaults()
+	k.Kanban.applyDefaults()
+	k.Projects.applyDefaults()
+	k.Forms.applyDefaults()
+	k.Pickers.applyDefaults()
+	k.General.applyDefaults()
 }

--- a/internal/tui/database_selection.go
+++ b/internal/tui/database_selection.go
@@ -19,16 +19,18 @@ func (m Model) handleConnectRemote() (tea.Model, tea.Cmd) {
 
 // updateDatabaseSelect handles keyboard input while in DatabaseSelectMode
 func (m Model) updateDatabaseSelect(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
+	km := m.Config.KeyMappings
+
 	switch msg.String() {
-	case "up", "k":
+	case km.Navigation.MoveUp, "up":
 		m.DatabasePicker.MoveCursorUp()
 		return m, nil
 
-	case "down", "j":
+	case km.Navigation.MoveDown, "down":
 		m.DatabasePicker.MoveCursorDown()
 		return m, nil
 
-	case "d", "D":
+	case km.Tasks.DeleteTask:
 		// Only allow delete on saved databases (not Local or Create New)
 		if m.DatabasePicker.IsSelectedSavedDatabase() {
 			selectedDB := m.DatabasePicker.SavedDatabases[m.DatabasePicker.Cursor]

--- a/internal/tui/helpers/tips.go
+++ b/internal/tui/helpers/tips.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"math/rand"
 	"reflect"
+	"strings"
 
 	"github.com/thenoetrevino/paso/internal/config"
 )
@@ -12,9 +13,9 @@ import (
 type Tip struct {
 	// Template is format string
 	Template string
-	// KeyFields are the names of KeyMappings struct fields to substitute
+	// KeyFields are dot-separated paths into the nested KeyMappings struct.
 	//
-	// Example: []string{"CreateProject", "NextProject"}
+	// Example: []string{"Projects.CreateProject", "Navigation.NextProject"}
 	KeyFields []string
 }
 
@@ -31,35 +32,35 @@ func NewTipGenerator(keyMappings *config.KeyMappings) *TipGenerator {
 		tips: []Tip{
 			{
 				Template:  "Press '%s' to create a new project, '%s'/'%s' to switch projects",
-				KeyFields: []string{"CreateProject", "NextProject", "PrevProject"},
+				KeyFields: []string{"Projects.CreateProject", "Navigation.NextProject", "Navigation.PrevProject"},
 			},
 			{
 				Template:  "Press '%s' to add task, '%s' to edit, '%s' to delete",
-				KeyFields: []string{"AddTask", "EditTask", "DeleteTask"},
+				KeyFields: []string{"Tasks.AddTask", "Tasks.EditTask", "Tasks.DeleteTask"},
 			},
 			{
 				Template:  "Navigate with '%s'/'%s' (columns), '%s'/'%s' (tasks)",
-				KeyFields: []string{"PrevColumn", "NextColumn", "PrevTask", "NextTask"},
+				KeyFields: []string{"Navigation.MoveLeft", "Navigation.MoveRight", "Navigation.MoveUp", "Navigation.MoveDown"},
 			},
 			{
 				Template:  "Move tasks with '%s'/'%s' (horizontal), '%s'/'%s' (vertical)",
-				KeyFields: []string{"MoveTaskLeft", "MoveTaskRight", "MoveTaskUp", "MoveTaskDown"},
+				KeyFields: []string{"Kanban.MoveTaskLeft", "Kanban.MoveTaskRight", "Kanban.MoveTaskUp", "Kanban.MoveTaskDown"},
 			},
 			{
 				Template:  "Press '%s' to create column, '%s' to rename, '%s' to delete",
-				KeyFields: []string{"CreateColumn", "RenameColumn", "DeleteColumn"},
+				KeyFields: []string{"Kanban.CreateColumn", "Kanban.RenameColumn", "Kanban.DeleteColumn"},
 			},
 			{
 				Template:  "Press '%s' to view task details, '%s' to toggle view mode",
-				KeyFields: []string{"ViewTask", "ToggleView"},
+				KeyFields: []string{"Tasks.ViewTask", "General.ToggleView"},
 			},
 			{
 				Template:  "Use '%s'/'%s' to scroll viewport when many columns exist",
-				KeyFields: []string{"ScrollViewportLeft", "ScrollViewportRight"},
+				KeyFields: []string{"Navigation.ScrollViewportLeft", "Navigation.ScrollViewportRight"},
 			},
 			{
 				Template:  "Press '%s' for help screen with all keyboard shortcuts",
-				KeyFields: []string{"ShowHelp"},
+				KeyFields: []string{"General.ShowHelp"},
 			},
 		},
 	}
@@ -81,12 +82,17 @@ func (tg *TipGenerator) generateTipText(tip Tip) string {
 	return fmt.Sprintf(tip.Template, keys...)
 }
 
-// getKeyBinding retrieves keybinding value by field name using reflection
-func (tg *TipGenerator) getKeyBinding(fieldName string) string {
+// getKeyBinding retrieves a keybinding value by a dot-separated path
+// into the nested KeyMappings struct (e.g. "Navigation.MoveUp").
+func (tg *TipGenerator) getKeyBinding(path string) string {
 	v := reflect.ValueOf(tg.keyMappings).Elem()
-	field := v.FieldByName(fieldName)
-	if !field.IsValid() {
-		return "?"
+
+	for segment := range strings.SplitSeq(path, ".") {
+		v = v.FieldByName(segment)
+		if !v.IsValid() {
+			return "?"
+		}
 	}
-	return field.String()
+
+	return v.String()
 }

--- a/internal/tui/model.go
+++ b/internal/tui/model.go
@@ -1013,34 +1013,55 @@ func (m *Model) initPriorityPicker(mode state.Mode) bool {
 	return true
 }
 
-// initTypePickerForForm initializes the type picker for use in task form mode.
-// Loads the current type from the form state.
-func (m *Model) initTypePickerForForm() bool {
-	// Get current type ID from form state
-	// If we're editing a task, get it from the task detail
-	// Otherwise, default to task (id=1)
-	currentTypeID := 1 // Default to task
+// initTypePicker initializes the type picker for both form and board modes.
+// - In form mode: Defaults to task (id=1) for new tasks, loads from DB for editing
+// - In board mode: Loads type from the currently selected task
+//
+// Returns false if there's a database error or (in board mode) no selected task.
+func (m *Model) initTypePicker(mode state.Mode) bool {
+	var currentTypeID int
+	var taskID int
 
-	// If editing an existing task, get the current type ID directly from database
-	if m.Forms.Form.EditingTaskID != 0 {
+	if mode == state.TicketFormMode {
+		currentTypeID = 1 // Default to task
+		taskID = m.Forms.Form.EditingTaskID
+
+		if taskID != 0 {
+			ctx, cancel := m.DBContext()
+			defer cancel()
+
+			typeID, _, err := m.App.TaskService.GetTaskTypeAndPriorityIDs(ctx, taskID)
+			if err != nil {
+				slog.Error("failed to get task type ID for type picker", "error", err)
+				return false
+			}
+			currentTypeID = typeID
+		}
+	} else {
+		task := m.getCurrentTask()
+		if task == nil {
+			m.UI.Notification.Add(state.LevelError, "No task selected")
+			return false
+		}
+
 		ctx, cancel := m.DBContext()
 		defer cancel()
 
-		typeID, _, err := m.App.TaskService.GetTaskTypeAndPriorityIDs(ctx, m.Forms.Form.EditingTaskID)
+		typeID, _, err := m.App.TaskService.GetTaskTypeAndPriorityIDs(ctx, task.ID)
 		if err != nil {
-			slog.Error("failed to get task type ID for type picker", "error", err)
+			slog.Error("failed to get task type ID for board picker", "error", err)
+			m.UI.Notification.Add(state.LevelError, "Failed to load task type")
 			return false
 		}
 
 		currentTypeID = typeID
+		taskID = task.ID
+		m.Forms.Form.EditingTaskID = taskID
 	}
 
-	// init to current type
 	m.Pickers.Type.SetSelectedTypeID(currentTypeID)
-
-	// set cursor to match the selected type, 0-indexed
 	m.Pickers.Type.SetCursor(currentTypeID - 1)
-	m.Pickers.Type.ReturnMode = state.TicketFormMode
+	m.Pickers.Type.ReturnMode = mode
 
 	return true
 }

--- a/internal/tui/renderers/list.go
+++ b/internal/tui/renderers/list.go
@@ -5,6 +5,7 @@ import (
 	"strings"
 
 	"charm.land/lipgloss/v2"
+	"github.com/thenoetrevino/paso/internal/config"
 	"github.com/thenoetrevino/paso/internal/models"
 	"github.com/thenoetrevino/paso/internal/tui/state"
 	"github.com/thenoetrevino/paso/internal/tui/theme"
@@ -34,6 +35,7 @@ func RenderListView(
 	sortOrder state.SortOrder,
 	width int,
 	height int,
+	km config.KeyMappings,
 ) string {
 	var output strings.Builder
 
@@ -152,7 +154,8 @@ func RenderListView(
 	helpStyle := lipgloss.NewStyle().
 		Foreground(lipgloss.Color(theme.Subtle)).
 		Italic(true)
-	helpText := "v: kanban  s: move to project  j/k: navigate"
+	helpText := fmt.Sprintf("%s: kanban  %s: move to project  %s/%s: navigate",
+		km.General.ToggleView, km.Tasks.MoveTaskToProject, km.Navigation.MoveDown, km.Navigation.MoveUp)
 	output.WriteString("\n")
 	output.WriteString(helpStyle.Render("  " + helpText))
 

--- a/internal/tui/renderers/renderers_integration_test.go
+++ b/internal/tui/renderers/renderers_integration_test.go
@@ -6,9 +6,15 @@ import (
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+	"github.com/thenoetrevino/paso/internal/config"
 	"github.com/thenoetrevino/paso/internal/models"
 	"github.com/thenoetrevino/paso/internal/tui/state"
 )
+
+// defaultKM returns default key mappings for test convenience.
+func defaultKM() config.KeyMappings {
+	return config.DefaultKeyMappings()
+}
 
 // TestRenderListViewBasic tests basic list view rendering
 func TestRenderListViewBasic(t *testing.T) {
@@ -32,7 +38,7 @@ func TestRenderListViewBasic(t *testing.T) {
 		},
 	}
 
-	output := RenderListView(rows, 0, 0, state.SortByTitle, state.SortAsc, 100, 20)
+	output := RenderListView(rows, 0, 0, state.SortByTitle, state.SortAsc, 100, 20, defaultKM())
 
 	require.NotEmpty(t, output)
 	assert.True(t, strings.Contains(output, "Task 1") || strings.Contains(output, "Task"))
@@ -43,7 +49,7 @@ func TestRenderListViewEmpty(t *testing.T) {
 	t.Parallel()
 	var rows []ListViewRow
 
-	output := RenderListView(rows, 0, 0, state.SortByTitle, state.SortAsc, 100, 20)
+	output := RenderListView(rows, 0, 0, state.SortByTitle, state.SortAsc, 100, 20, defaultKM())
 
 	require.NotEmpty(t, output)
 }
@@ -79,7 +85,7 @@ func TestRenderListViewSelectedRow(t *testing.T) {
 	}
 
 	// Select the middle row
-	output := RenderListView(rows, 1, 0, state.SortByTitle, state.SortAsc, 100, 20)
+	output := RenderListView(rows, 1, 0, state.SortByTitle, state.SortAsc, 100, 20, defaultKM())
 
 	require.NotEmpty(t, output)
 }
@@ -101,7 +107,7 @@ func TestRenderListViewScrolling(t *testing.T) {
 	}
 
 	// Test with scroll offset
-	output := RenderListView(rows, 10, 5, state.SortByTitle, state.SortAsc, 100, 20)
+	output := RenderListView(rows, 10, 5, state.SortByTitle, state.SortAsc, 100, 20, defaultKM())
 
 	require.NotEmpty(t, output)
 }
@@ -136,7 +142,7 @@ func TestRenderListViewDifferentSorts(t *testing.T) {
 	for _, sortField := range sorts {
 		t.Run("sort", func(t *testing.T) {
 			t.Parallel()
-			output := RenderListView(rows, 0, 0, sortField, state.SortAsc, 100, 20)
+			output := RenderListView(rows, 0, 0, sortField, state.SortAsc, 100, 20, defaultKM())
 
 			assert.NotEmpty(t, output)
 		})
@@ -165,8 +171,8 @@ func TestRenderListViewSortOrders(t *testing.T) {
 		},
 	}
 
-	ascOutput := RenderListView(rows, 0, 0, state.SortByTitle, state.SortAsc, 100, 20)
-	descOutput := RenderListView(rows, 0, 0, state.SortByTitle, state.SortDesc, 100, 20)
+	ascOutput := RenderListView(rows, 0, 0, state.SortByTitle, state.SortAsc, 100, 20, defaultKM())
+	descOutput := RenderListView(rows, 0, 0, state.SortByTitle, state.SortDesc, 100, 20, defaultKM())
 
 	require.NotEmpty(t, ascOutput)
 	require.NotEmpty(t, descOutput)
@@ -187,7 +193,7 @@ func TestRenderListViewNarrowWidth(t *testing.T) {
 	}
 
 	// Very narrow width
-	output := RenderListView(rows, 0, 0, state.SortByTitle, state.SortAsc, 30, 10)
+	output := RenderListView(rows, 0, 0, state.SortByTitle, state.SortAsc, 30, 10, defaultKM())
 
 	require.NotEmpty(t, output)
 
@@ -215,7 +221,7 @@ func TestRenderListViewLargeWidth(t *testing.T) {
 	}
 
 	// Very large width
-	output := RenderListView(rows, 0, 0, state.SortByTitle, state.SortAsc, 500, 50)
+	output := RenderListView(rows, 0, 0, state.SortByTitle, state.SortAsc, 500, 50, defaultKM())
 
 	require.NotEmpty(t, output)
 }
@@ -235,7 +241,7 @@ func TestRenderListViewManyRows(t *testing.T) {
 		}
 	}
 
-	output := RenderListView(rows, 50, 10, state.SortByTitle, state.SortAsc, 100, 20)
+	output := RenderListView(rows, 50, 10, state.SortByTitle, state.SortAsc, 100, 20, defaultKM())
 
 	require.NotEmpty(t, output)
 }
@@ -262,7 +268,7 @@ func TestRenderListViewUnicodeContent(t *testing.T) {
 		},
 	}
 
-	output := RenderListView(rows, 0, 0, state.SortByTitle, state.SortAsc, 100, 20)
+	output := RenderListView(rows, 0, 0, state.SortByTitle, state.SortAsc, 100, 20, defaultKM())
 
 	require.NotEmpty(t, output)
 }
@@ -284,15 +290,15 @@ func TestRenderListViewScrollBehavior(t *testing.T) {
 	}
 
 	// Test with scroll at top
-	outputTop := RenderListView(rows, 0, 0, state.SortByTitle, state.SortAsc, 100, 10)
+	outputTop := RenderListView(rows, 0, 0, state.SortByTitle, state.SortAsc, 100, 10, defaultKM())
 	require.NotEmpty(t, outputTop)
 
 	// Test with scroll in middle
-	outputMid := RenderListView(rows, 10, 10, state.SortByTitle, state.SortAsc, 100, 10)
+	outputMid := RenderListView(rows, 10, 10, state.SortByTitle, state.SortAsc, 100, 10, defaultKM())
 	require.NotEmpty(t, outputMid)
 
 	// Test with scroll at bottom
-	outputBot := RenderListView(rows, 20, 20, state.SortByTitle, state.SortAsc, 100, 10)
+	outputBot := RenderListView(rows, 20, 20, state.SortByTitle, state.SortAsc, 100, 10, defaultKM())
 	require.NotEmpty(t, outputBot)
 }
 
@@ -311,7 +317,7 @@ func TestRenderListViewMinimalSize(t *testing.T) {
 	}
 
 	// Minimal space
-	output := RenderListView(rows, 0, 0, state.SortByTitle, state.SortAsc, 20, 3)
+	output := RenderListView(rows, 0, 0, state.SortByTitle, state.SortAsc, 20, 3, defaultKM())
 
 	require.NotEmpty(t, output)
 }
@@ -330,7 +336,7 @@ func TestRenderListViewHeaderPresent(t *testing.T) {
 		},
 	}
 
-	output := RenderListView(rows, 0, 0, state.SortByTitle, state.SortAsc, 100, 20) // Will have table header
+	output := RenderListView(rows, 0, 0, state.SortByTitle, state.SortAsc, 100, 20, defaultKM()) // Will have table header
 
 	// Should have multiple lines (header + separator + rows)
 	lines := strings.Split(strings.TrimSpace(output), "\n")
@@ -351,8 +357,8 @@ func TestRenderListViewConsistency(t *testing.T) {
 		},
 	}
 
-	output1 := RenderListView(rows, 0, 0, state.SortByTitle, state.SortAsc, 100, 20)
-	output2 := RenderListView(rows, 0, 0, state.SortByTitle, state.SortAsc, 100, 20)
+	output1 := RenderListView(rows, 0, 0, state.SortByTitle, state.SortAsc, 100, 20, defaultKM())
+	output2 := RenderListView(rows, 0, 0, state.SortByTitle, state.SortAsc, 100, 20, defaultKM())
 
 	assert.Equal(t, output1, output2)
 }
@@ -389,7 +395,7 @@ func TestRenderListViewEdgeCases(t *testing.T) {
 		},
 	}
 
-	output := RenderListView(rows, 0, 0, state.SortByTitle, state.SortAsc, 100, 0)
+	output := RenderListView(rows, 0, 0, state.SortByTitle, state.SortAsc, 100, 0, defaultKM())
 
 	require.NotEmpty(t, output)
 }

--- a/internal/tui/update.go
+++ b/internal/tui/update.go
@@ -320,7 +320,7 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 }
 
 func (m Model) handleKeyMsg(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
-	if msg.String() == m.Config.KeyMappings.Suspend {
+	if msg.String() == m.Config.KeyMappings.General.Suspend {
 		return m, tea.Suspend
 	}
 
@@ -341,7 +341,7 @@ func (m Model) handleKeyMsg(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 		return m.handleProjectBranchConfirm(msg)
 	case state.TicketFormLoadingMode:
 		switch msg.String() {
-		case "esc", m.Config.KeyMappings.Quit:
+		case "esc", m.Config.KeyMappings.General.Quit:
 			m.LoadingGitInfo = false
 			m.SpinnerFrame = 0
 			m.UIState.Mode = state.NormalMode
@@ -350,7 +350,7 @@ func (m Model) handleKeyMsg(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 		return m, nil
 	case state.ProjectFormLoadingMode:
 		switch msg.String() {
-		case "esc", m.Config.KeyMappings.Quit:
+		case "esc", m.Config.KeyMappings.General.Quit:
 			m.LoadingGitInfo = false
 			m.LoadingBranches = false
 			m.Forms.Form.ClearProjectForm()
@@ -362,14 +362,14 @@ func (m Model) handleKeyMsg(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 		return m.handleCommentsViewInput(msg)
 	case state.HelpMode:
 		switch msg.String() {
-		case m.Config.KeyMappings.ShowHelp, m.Config.KeyMappings.Quit, "esc", "enter", " ":
+		case m.Config.KeyMappings.General.ShowHelp, m.Config.KeyMappings.General.Quit, "esc", "enter", " ":
 			m.UIState.Mode = state.NormalMode
 			return m, nil
 		}
 		return m, nil
 	case state.TaskFormHelpMode:
 		switch msg.String() {
-		case "ctrl+h", "esc":
+		case m.Config.KeyMappings.Forms.ShowHelp, "esc":
 			m.UIState.Mode = state.TicketFormMode
 			return m, nil
 		}

--- a/internal/tui/update_comments.go
+++ b/internal/tui/update_comments.go
@@ -10,19 +10,20 @@ import (
 // handleCommentsViewInput processes input in comments view mode
 func (m Model) handleCommentsViewInput(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 	key := msg.String()
+	km := m.Config.KeyMappings
 
 	switch key {
-	case "up", "k":
+	case km.Navigation.MoveUp, "up":
 		return m.handleCommentsViewUp()
-	case "down", "j":
+	case km.Navigation.MoveDown, "down":
 		return m.handleCommentsViewDown()
-	case "enter", "e":
+	case "enter", km.Tasks.EditTask:
 		return m.handleCommentsViewEdit()
-	case "a":
+	case km.Tasks.AddTask:
 		return m.handleCommentsViewAdd()
-	case "d":
+	case km.Tasks.DeleteTask:
 		return m.handleCommentsViewDelete()
-	case "esc", "q":
+	case "esc", km.General.Quit:
 		return m.handleCommentsViewClose()
 	}
 

--- a/internal/tui/update_filter.go
+++ b/internal/tui/update_filter.go
@@ -12,8 +12,10 @@ func (m Model) handleFilterBarMode(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 		return m.handleSearchInput(msg)
 	}
 
+	km := m.Config.KeyMappings
+
 	switch msg.String() {
-	case "esc", "q":
+	case "esc", km.General.Quit:
 		m.UI.Filter.IsActive = false
 		m.UIState.Mode = state.NormalMode
 		return m, nil
@@ -33,11 +35,11 @@ func (m Model) handleFilterBarMode(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 		}
 		return m.openFilterPicker()
 
-	case "h", "left":
+	case km.Navigation.MoveLeft, "left":
 		m.UI.Filter.MoveFocusLeft()
 		return m, nil
 
-	case "l", "right":
+	case km.Navigation.MoveRight, "right":
 		m.UI.Filter.MoveFocusRight()
 		return m, nil
 

--- a/internal/tui/update_forms.go
+++ b/internal/tui/update_forms.go
@@ -459,7 +459,7 @@ func (m Model) updateTaskForm(msg tea.Msg) (tea.Model, tea.Cmd) {
 
 		case km.Forms.EditType:
 			// Open type picker
-			if m.initTypePickerForForm() {
+			if m.initTypePicker(state.TicketFormMode) {
 				m.UIState.Mode = state.TypePickerMode
 			}
 			return m, nil

--- a/internal/tui/update_forms.go
+++ b/internal/tui/update_forms.go
@@ -410,6 +410,7 @@ func (m Model) updateTaskForm(msg tea.Msg) (tea.Model, tea.Cmd) {
 	}
 
 	// Check for keyboard shortcuts before passing to form
+	km := m.Config.KeyMappings
 	if keyMsg, ok := msg.(tea.KeyMsg); ok {
 		switch keyMsg.String() {
 		case "esc":
@@ -428,61 +429,61 @@ func (m Model) updateTaskForm(msg tea.Msg) (tea.Model, tea.Cmd) {
 			m.Forms.Form.ClearTaskForm()
 			return m, tea.ClearScreen
 
-		case "ctrl+p":
+		case km.Forms.EditParentTask:
 			// Open parent picker
 			if m.initParentPickerForForm() {
 				m.UIState.Mode = state.ParentPickerMode
 			}
 			return m, nil
 
-		case "ctrl+c":
+		case km.Forms.EditChildTask:
 			// Open child picker
 			if m.initChildPickerForForm() {
 				m.UIState.Mode = state.ChildPickerMode
 			}
 			return m, nil
 
-		case "ctrl+l":
+		case km.Forms.EditLabels:
 			// Open label picker
 			if m.initLabelPicker(state.TicketFormMode) {
 				m.UIState.Mode = state.LabelPickerMode
 			}
 			return m, nil
 
-		case "ctrl+r":
+		case km.Forms.EditPriority:
 			// Open priority picker
 			if m.initPriorityPicker(state.TicketFormMode) {
 				m.UIState.Mode = state.PriorityPickerMode
 			}
 			return m, nil
 
-		case "ctrl+t":
+		case km.Forms.EditType:
 			// Open type picker
 			if m.initTypePickerForForm() {
 				m.UIState.Mode = state.TypePickerMode
 			}
 			return m, nil
 
-		case "ctrl+a":
+		case km.Forms.EditAssignee:
 			// Open assignee picker
 			if m.initAssigneePicker(state.TicketFormMode) {
 				m.UIState.Mode = state.AssigneePickerMode
 			}
 			return m, nil
 
-		case "ctrl+e":
+		case km.Forms.EditEstimate:
 			// Open estimate input layer
 			m.initEstimateInputForForm()
 			m.UIState.Mode = state.EstimateInputMode
 			return m, nil
 
-		case "ctrl+d":
+		case km.Forms.EditDueDate:
 			// Open due date picker
 			m.initDatePickerForForm()
 			m.UIState.Mode = state.DatePickerMode
 			return m, nil
 
-		case "ctrl+h":
+		case km.Forms.ShowHelp:
 			// Open task form help menu
 			m.UIState.Mode = state.TaskFormHelpMode
 			return m, nil
@@ -508,11 +509,11 @@ func (m Model) updateTaskForm(msg tea.Msg) (tea.Model, tea.Cmd) {
 			}
 			// Otherwise let form handle it
 
-		case "ctrl+n":
+		case km.Forms.OpenCommentsView:
 			// Open comments view
 			return m.handleOpenCommentsView()
 
-		case m.Config.KeyMappings.SaveForm:
+		case km.Forms.SaveForm:
 			// Quick save via C-s
 			return m.handleFormSave(formConfig{
 				form: m.Forms.Form.TaskForm,
@@ -597,7 +598,7 @@ func (m Model) updateProjectForm(msg tea.Msg) (tea.Model, tea.Cmd) {
 			m.Forms.Form.ClearProjectForm()
 			return m, tea.ClearScreen
 
-		case m.Config.KeyMappings.SaveForm:
+		case m.Config.KeyMappings.Forms.SaveForm:
 			return m.handleFormSave(formConfig{
 				form: m.Forms.Form.ProjectForm,
 				setForm: func(f *huh.Form) {
@@ -612,7 +613,7 @@ func (m Model) updateProjectForm(msg tea.Msg) (tea.Model, tea.Cmd) {
 				confirmPtr: &m.Forms.Form.FormProjectConfirm,
 			})
 
-		case "f5":
+		case m.Config.KeyMappings.Forms.RefreshGitData:
 			return m.handleRefreshGitData()
 		}
 	}

--- a/internal/tui/update_listview.go
+++ b/internal/tui/update_listview.go
@@ -26,6 +26,8 @@ func (m Model) handleMoveTaskToProject() (tea.Model, tea.Cmd) {
 }
 
 func (m Model) handleStatusPickerMode(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
+	km := m.Config.KeyMappings
+
 	switch msg.String() {
 	case "esc":
 		m.Pickers.Status.Reset()
@@ -33,10 +35,10 @@ func (m Model) handleStatusPickerMode(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 		return m, nil
 	case "enter":
 		return m.confirmStatusChange()
-	case "j", "down":
+	case km.Navigation.MoveDown, "down":
 		m.Pickers.Status.MoveDown()
 		return m, nil
-	case "k", "up":
+	case km.Navigation.MoveUp, "up":
 		m.Pickers.Status.MoveUp()
 		return m, nil
 	}

--- a/internal/tui/update_normal.go
+++ b/internal/tui/update_normal.go
@@ -51,73 +51,73 @@ func (m Model) handleNormalMode(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 	km := m.Config.KeyMappings
 
 	switch key {
-	case km.Quit, "ctrl+c":
+	case km.General.Quit, "ctrl+c":
 		return m.handleQuit()
-	case km.ShowHelp:
+	case km.General.ShowHelp:
 		return m.handleShowHelp()
-	case km.AddTask:
+	case km.Tasks.AddTask:
 		return m.handleAddTask()
-	case km.EditTask:
+	case km.Tasks.EditTask:
 		return m.handleEditTask()
-	case km.DeleteTask:
+	case km.Tasks.DeleteTask:
 		return m.handleDeleteTask()
-	case km.ViewTask:
+	case km.Tasks.ViewTask:
 		return m.handleEditTask()
-	case km.CreateColumn:
+	case km.Kanban.CreateColumn:
 		return m.handleCreateColumn()
-	case km.RenameColumn:
+	case km.Kanban.RenameColumn:
 		return m.handleRenameColumn()
-	case km.DeleteColumn:
+	case km.Kanban.DeleteColumn:
 		return m.handleDeleteColumn()
-	case km.ScrollViewportRight:
+	case km.Navigation.ScrollViewportRight:
 		return m.handleScrollRight()
-	case km.ScrollViewportLeft:
+	case km.Navigation.ScrollViewportLeft:
 		return m.handleScrollLeft()
-	case km.PrevColumn, "left":
+	case km.Navigation.MoveLeft, "left":
 		return m.handleNavigateLeft()
-	case km.NextColumn, "right":
+	case km.Navigation.MoveRight, "right":
 		return m.handleNavigateRight()
-	case km.NextTask, "down":
+	case km.Navigation.MoveDown, "down":
 		return m.handleNavigateDown()
-	case km.PrevTask, "up":
+	case km.Navigation.MoveUp, "up":
 		return m.handleNavigateUp()
-	case km.MoveTaskRight:
+	case km.Kanban.MoveTaskRight:
 		return m.handleMoveTaskRight()
-	case km.MoveTaskLeft:
+	case km.Kanban.MoveTaskLeft:
 		return m.handleMoveTaskLeft()
-	case km.MoveTaskUp:
+	case km.Kanban.MoveTaskUp:
 		return m.handleMoveTaskUp()
-	case km.MoveTaskDown:
+	case km.Kanban.MoveTaskDown:
 		return m.handleMoveTaskDown()
-	case km.PrevProject:
+	case km.Navigation.PrevProject:
 		return m.handlePrevProject()
-	case km.NextProject:
+	case km.Navigation.NextProject:
 		return m.handleNextProject()
-	case km.CreateProject:
+	case km.Projects.CreateProject:
 		return m.handleCreateProject()
-	case km.EditProject:
+	case km.Projects.EditProject:
 		return m.handleEditProject()
-	case km.DeleteProject:
+	case km.Projects.DeleteProject:
 		return m.handleDeleteProject()
-	case km.ToggleView:
+	case km.General.ToggleView:
 		return m.handleToggleView()
-	case km.MoveTaskToProject:
+	case km.Tasks.MoveTaskToProject:
 		return m.handleMoveTaskToProject()
-	case km.ConnectRemote:
+	case km.General.ConnectRemote:
 		return m.handleConnectRemote()
-	case km.EditLabels:
+	case km.Tasks.EditLabels:
 		return m.handleQuickEditLabels()
-	case km.EditPriority:
+	case km.Tasks.EditPriority:
 		return m.handleQuickEditPriority()
-	case km.EditAssignee:
+	case km.Tasks.EditAssignee:
 		return m.handleQuickEditAssignee()
-	case km.EditEstimate:
+	case km.Tasks.EditEstimate:
 		return m.handleQuickEditEstimate()
-	case km.EditDueDate:
+	case km.Tasks.EditDueDate:
 		return m.handleQuickEditDueDate()
-	case "/":
+	case km.General.Search:
 		return m.handleEnterSearchChip()
-	case km.FilterBar:
+	case km.General.FilterBar:
 		return m.handleEnterFilterBar()
 	}
 

--- a/internal/tui/update_normal.go
+++ b/internal/tui/update_normal.go
@@ -115,6 +115,8 @@ func (m Model) handleNormalMode(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 		return m.handleQuickEditEstimate()
 	case km.Tasks.EditDueDate:
 		return m.handleQuickEditDueDate()
+	case km.Tasks.EditType:
+		return m.handleQuickEditType()
 	case km.General.Search:
 		return m.handleEnterSearchChip()
 	case km.General.FilterBar:
@@ -583,5 +585,13 @@ func (m Model) handleQuickEditDueDate() (tea.Model, tea.Cmd) {
 		return m, nil
 	}
 	m.UIState.Mode = state.DatePickerMode
+	return m, nil
+}
+
+func (m Model) handleQuickEditType() (tea.Model, tea.Cmd) {
+	if !m.initTypePicker(state.NormalMode) {
+		return m, nil
+	}
+	m.UIState.Mode = state.TypePickerMode
 	return m, nil
 }

--- a/internal/tui/update_notes.go
+++ b/internal/tui/update_notes.go
@@ -51,7 +51,7 @@ func (m Model) updateCommentEdit(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 		}
 		return m, nil
 
-	case km.Forms.OpenCommentsView:
+	case km.Forms.OpenCommentsView, "n":
 		// Open form to create a new comment
 		m.Forms.Form.FormCommentMessage = ""
 		m.Forms.Form.EditingCommentID = 0

--- a/internal/tui/update_notes.go
+++ b/internal/tui/update_notes.go
@@ -12,20 +12,22 @@ import (
 // updateCommentEdit handles keyboard input in the comment editing mode.
 // This function processes navigation (up/down), opening forms for editing, and comment deletion.
 func (m Model) updateCommentEdit(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
+	km := m.Config.KeyMappings
+
 	switch msg.String() {
 	case "esc":
 		// Return to ticket form mode
 		m.UIState.Mode = state.TicketFormMode
 		return m, nil
 
-	case "j", "down":
+	case km.Navigation.MoveDown, "down":
 		// Move cursor down
 		if len(m.Forms.Comment.Items) > 0 {
 			m.Forms.Comment.MoveCursorDown(len(m.Forms.Comment.Items) - 1)
 		}
 		return m, nil
 
-	case "k", "up":
+	case km.Navigation.MoveUp, "up":
 		// Move cursor up
 		m.Forms.Comment.MoveCursorUp()
 		return m, nil
@@ -49,7 +51,7 @@ func (m Model) updateCommentEdit(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 		}
 		return m, nil
 
-	case "ctrl+n", "n":
+	case km.Forms.OpenCommentsView:
 		// Open form to create a new comment
 		m.Forms.Form.FormCommentMessage = ""
 		m.Forms.Form.EditingCommentID = 0
@@ -59,7 +61,7 @@ func (m Model) updateCommentEdit(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 		m.UIState.Mode = state.CommentFormMode
 		return m, m.Forms.Form.CommentForm.Init()
 
-	case "delete", "d":
+	case "delete", km.Tasks.DeleteTask:
 		// Delete the selected activity (only comments are deletable)
 		if len(m.Forms.Comment.Items) > 0 && m.Forms.Comment.Cursor < len(m.Forms.Comment.Items) {
 			activity := m.Forms.Comment.Items[m.Forms.Comment.Cursor].Activity

--- a/internal/tui/update_pickers.go
+++ b/internal/tui/update_pickers.go
@@ -36,6 +36,8 @@ func (m Model) updateLabelPicker(msg tea.Msg) (tea.Model, tea.Cmd) {
 	filteredItems := m.getFilteredLabelPickerItems()
 	maxIdx := len(filteredItems) // +1 for "create new label" option
 
+	km := m.Config.KeyMappings
+
 	switch keyMsg.String() {
 	case "esc":
 		// Close picker and return to appropriate mode
@@ -67,14 +69,14 @@ func (m Model) updateLabelPicker(msg tea.Msg) (tea.Model, tea.Cmd) {
 		m.Pickers.Label.Cursor = 0
 		return m, nil
 
-	case "up", "k":
+	case km.Navigation.MoveUp, "up":
 		// Move cursor up
 		if m.Pickers.Label.Cursor > 0 {
 			m.Pickers.Label.Cursor--
 		}
 		return m, nil
 
-	case "down", "j":
+	case km.Navigation.MoveDown, "down":
 		// Move cursor down
 		if m.Pickers.Label.Cursor < maxIdx {
 			m.Pickers.Label.Cursor++
@@ -135,7 +137,7 @@ func (m Model) updateLabelPicker(msg tea.Msg) (tea.Model, tea.Cmd) {
 		}
 		return m, nil
 
-	case "ctrl+d":
+	case km.Pickers.DeleteLabel:
 		// Delete the label at cursor position (only if cursor is on a label, not "+ Create new label")
 		// Not available in filter mode
 		if m.Pickers.Label.ReturnMode != state.FilterBarMode && m.Pickers.Label.Cursor < len(filteredItems) {
@@ -229,6 +231,7 @@ func (m Model) updateLabelNameInput(keyMsg tea.KeyMsg) (tea.Model, tea.Cmd) {
 func (m Model) updateLabelColorPicker(keyMsg tea.KeyMsg) (tea.Model, tea.Cmd) {
 	colors := renderers.GetDefaultLabelColors()
 	maxIdx := len(colors) - 1
+	km := m.Config.KeyMappings
 
 	switch keyMsg.String() {
 	case "esc":
@@ -237,13 +240,13 @@ func (m Model) updateLabelColorPicker(keyMsg tea.KeyMsg) (tea.Model, tea.Cmd) {
 		m.Pickers.Label.NameBuffer = ""
 		return m, nil
 
-	case "up", "k":
+	case km.Navigation.MoveUp, "up":
 		if m.Pickers.Label.ColorIdx > 0 {
 			m.Pickers.Label.ColorIdx--
 		}
 		return m, nil
 
-	case "down", "j":
+	case km.Navigation.MoveDown, "down":
 		if m.Pickers.Label.ColorIdx < maxIdx {
 			m.Pickers.Label.ColorIdx++
 		}
@@ -322,6 +325,7 @@ func (m Model) updateParentPicker(msg tea.Msg) (tea.Model, tea.Cmd) {
 	// Get filtered items to determine bounds
 	filteredItems := m.Pickers.Parent.GetFilteredItems()
 	maxIdx := len(filteredItems) - 1
+	km := m.Config.KeyMappings
 
 	switch keyMsg.String() {
 	case "esc":
@@ -341,12 +345,12 @@ func (m Model) updateParentPicker(msg tea.Msg) (tea.Model, tea.Cmd) {
 		m.Pickers.Parent.Cursor = 0
 		return m, nil
 
-	case "up", "k":
+	case km.Navigation.MoveUp, "up":
 		// Move cursor up
 		m.Pickers.Parent.MoveCursorUp()
 		return m, nil
 
-	case "down", "j":
+	case km.Navigation.MoveDown, "down":
 		// Move cursor down
 		m.Pickers.Parent.MoveCursorDown(maxIdx)
 		return m, nil
@@ -477,6 +481,7 @@ func (m Model) updateChildPicker(msg tea.Msg) (tea.Model, tea.Cmd) {
 	// Get filtered items to determine bounds
 	filteredItems := m.Pickers.Child.GetFilteredItems()
 	maxIdx := len(filteredItems) - 1
+	km := m.Config.KeyMappings
 
 	switch keyMsg.String() {
 	case "esc":
@@ -496,12 +501,12 @@ func (m Model) updateChildPicker(msg tea.Msg) (tea.Model, tea.Cmd) {
 		m.Pickers.Child.Cursor = 0
 		return m, nil
 
-	case "up", "k":
+	case km.Navigation.MoveUp, "up":
 		// Move cursor up
 		m.Pickers.Child.MoveCursorUp()
 		return m, nil
 
-	case "down", "j":
+	case km.Navigation.MoveDown, "down":
 		// Move cursor down
 		m.Pickers.Child.MoveCursorDown(maxIdx)
 		return m, nil
@@ -621,6 +626,8 @@ func (m Model) updatePriorityPicker(msg tea.Msg) (tea.Model, tea.Cmd) {
 		return m, nil
 	}
 
+	km := m.Config.KeyMappings
+
 	switch keyMsg.String() {
 	case "esc":
 		// Return to ticket form mode without changing priority
@@ -628,12 +635,12 @@ func (m Model) updatePriorityPicker(msg tea.Msg) (tea.Model, tea.Cmd) {
 		m.Pickers.Priority.Reset()
 		return m, nil
 
-	case "up", "k":
+	case km.Navigation.MoveUp, "up":
 		// Move cursor up
 		m.Pickers.Priority.MoveUp()
 		return m, nil
 
-	case "down", "j":
+	case km.Navigation.MoveDown, "down":
 		// Move cursor down
 		m.Pickers.Priority.MoveDown()
 		return m, nil
@@ -709,6 +716,8 @@ func (m Model) updateTypePicker(msg tea.Msg) (tea.Model, tea.Cmd) {
 		return m, nil
 	}
 
+	km := m.Config.KeyMappings
+
 	switch keyMsg.String() {
 	case "esc":
 		// Return to ticket form mode without changing type
@@ -716,12 +725,12 @@ func (m Model) updateTypePicker(msg tea.Msg) (tea.Model, tea.Cmd) {
 		m.Pickers.Type.Reset()
 		return m, nil
 
-	case "up", "k":
+	case km.Navigation.MoveUp, "up":
 		// Move cursor up
 		m.Pickers.Type.MoveUp()
 		return m, nil
 
-	case "down", "j":
+	case km.Navigation.MoveDown, "down":
 		// Move cursor down
 		m.Pickers.Type.MoveDown()
 		return m, nil
@@ -791,6 +800,8 @@ func (m Model) updateProjectPicker(msg tea.Msg) (tea.Model, tea.Cmd) {
 		return m, nil
 	}
 
+	km := m.Config.KeyMappings
+
 	switch keyMsg.String() {
 	case "esc":
 		m.UIState.Mode = m.Pickers.Project.ReturnMode
@@ -800,11 +811,11 @@ func (m Model) updateProjectPicker(msg tea.Msg) (tea.Model, tea.Cmd) {
 		m.Pickers.Project.Reset()
 		return m, nil
 
-	case "up", "k":
+	case km.Navigation.MoveUp, "up":
 		m.Pickers.Project.MoveUp()
 		return m, nil
 
-	case "down", "j":
+	case km.Navigation.MoveDown, "down":
 		m.Pickers.Project.MoveDown()
 		return m, nil
 
@@ -847,6 +858,8 @@ func (m Model) updateAssigneePicker(msg tea.Msg) (tea.Model, tea.Cmd) {
 		return m, nil
 	}
 
+	km := m.Config.KeyMappings
+
 	switch keyMsg.String() {
 	case "esc":
 		m.UIState.Mode = m.Pickers.Assignee.ReturnMode
@@ -857,11 +870,11 @@ func (m Model) updateAssigneePicker(msg tea.Msg) (tea.Model, tea.Cmd) {
 		m.Pickers.Assignee.Reset()
 		return m, nil
 
-	case "up", "k":
+	case km.Navigation.MoveUp, "up":
 		m.Pickers.Assignee.MoveUp()
 		return m, nil
 
-	case "down", "j":
+	case km.Navigation.MoveDown, "down":
 		m.Pickers.Assignee.MoveDown()
 		return m, nil
 
@@ -1024,27 +1037,27 @@ func (m Model) updateDatePicker(msg tea.Msg) (tea.Model, tea.Cmd) {
 		m.UIState.Mode = m.Pickers.DatePicker.ReturnMode
 		return m, nil
 
-	case km.PrevTask, "up":
+	case km.Navigation.MoveUp, "up":
 		m.Pickers.DatePicker.MoveWeek(-1) // Move up 7 days
 		return m, nil
 
-	case km.NextTask, "down":
+	case km.Navigation.MoveDown, "down":
 		m.Pickers.DatePicker.MoveWeek(1) // Move down 7 days
 		return m, nil
 
-	case km.PrevColumn, "left":
+	case km.Navigation.MoveLeft, "left":
 		m.Pickers.DatePicker.MoveDay(-1) // Previous day
 		return m, nil
 
-	case km.NextColumn, "right":
+	case km.Navigation.MoveRight, "right":
 		m.Pickers.DatePicker.MoveDay(1) // Next day
 		return m, nil
 
-	case km.ScrollViewportLeft:
+	case km.Navigation.ScrollViewportLeft:
 		m.Pickers.DatePicker.PrevMonth() // Previous month
 		return m, nil
 
-	case km.ScrollViewportRight:
+	case km.Navigation.ScrollViewportRight:
 		m.Pickers.DatePicker.NextMonth() // Next month
 		return m, nil
 
@@ -1117,6 +1130,8 @@ func (m Model) updateRelationTypePicker(msg tea.Msg) (tea.Model, tea.Cmd) {
 		return m, nil
 	}
 
+	km := m.Config.KeyMappings
+
 	switch keyMsg.String() {
 	case "esc":
 		// Return to previous picker (parent or child) without changing relation type
@@ -1124,12 +1139,12 @@ func (m Model) updateRelationTypePicker(msg tea.Msg) (tea.Model, tea.Cmd) {
 		m.Pickers.RelationType.Reset()
 		return m, nil
 
-	case "up", "k":
+	case km.Navigation.MoveUp, "up":
 		// Move cursor up
 		m.Pickers.RelationType.MoveUp()
 		return m, nil
 
-	case "down", "j":
+	case km.Navigation.MoveDown, "down":
 		// Move cursor down
 		m.Pickers.RelationType.MoveDown()
 		return m, nil

--- a/internal/tui/update_pickers.go
+++ b/internal/tui/update_pickers.go
@@ -784,8 +784,10 @@ func (m Model) updateTypePicker(msg tea.Msg) (tea.Model, tea.Cmd) {
 			m.Pickers.Type.SetSelectedTypeID(selectedType.ID)
 		}
 
-		// Return to ticket form mode
 		m.UIState.Mode = m.Pickers.Type.ReturnMode
+		if m.Pickers.Type.ReturnMode == state.NormalMode {
+			m.Forms.Form.EditingTaskID = 0
+		}
 		return m, nil
 	}
 

--- a/internal/tui/view_board.go
+++ b/internal/tui/view_board.go
@@ -219,6 +219,7 @@ func (m Model) viewListView() string {
 		m.UI.ListView.SortOrder(),
 		m.UIState.Width(),
 		listHeight,
+		m.Config.KeyMappings,
 	)
 
 	statusBar := components.RenderStatusBar(components.StatusBarProps{

--- a/internal/tui/view_layers.go
+++ b/internal/tui/view_layers.go
@@ -317,22 +317,31 @@ TASKS
   %s     Add new task
   %s     Edit selected task
   %s     Delete selected task
+  %s     Edit task details
+  %s     Edit labels
+  %s     Edit priority
+  %s     Edit assignee
+  %s     Edit estimate
+  %s     Edit due date
+  %s     Edit type
+  %s     Edit parent task
+  %s     Edit child task
+  %s     Move task to another project
+
+KANBAN
+  %s     Create new column (after current)
+  %s     Rename current column
+  %s     Delete current column
   %s     Move task to previous column
   %s     Move task to next column
   %s     Move task up in column
   %s     Move task down in column
-  %s     Edit task details
-
-COLUMNS
-  %s     Create new column (after current)
-  %s     Rename current column
-  %s     Delete current column
 
 NAVIGATION
-  %s     Move to previous column
-  %s     Move to next column
-  %s     Move to previous task
-  %s     Move to next task
+  %s     Move left
+  %s     Move right
+  %s     Move up
+  %s     Move down
   %s     Scroll viewport left
   %s     Scroll viewport right
 
@@ -340,45 +349,85 @@ PROJECTS
   %s     Switch to previous project
   %s     Switch to next project
   %s     Create new project
+  %s     Edit current project
   %s     Delete current project
 
 VIEW
   %s     Toggle between kanban and list view
-  %s     Move task to another project
-  /         Search tasks
+  %s     Search tasks
+  %s     Open filter bar
+
+FORMS
+  %s     Save form
+  %s     Open comments view
+  %s     Refresh git data
+  %s     Edit labels
+  %s     Edit parent task
+  %s     Edit child task
+  %s     Edit priority
+  %s     Edit type
+  %s     Edit assignee
+  %s     Edit estimate
+  %s     Edit due date
+  %s     Show form help
 
 OTHER
   %s     Show this help
+  %s     Connect to remote database
   %s     Suspend (resume with fg)
   %s     Quit
 
 Press any key to close`,
-		km.AddTask,
-		km.EditTask,
-		km.DeleteTask,
-		km.MoveTaskLeft,
-		km.MoveTaskRight,
-		km.MoveTaskUp,
-		km.MoveTaskDown,
-		km.ViewTask,
-		km.CreateColumn,
-		km.RenameColumn,
-		km.DeleteColumn,
-		km.PrevColumn,
-		km.NextColumn,
-		km.PrevTask,
-		km.NextTask,
-		km.ScrollViewportLeft,
-		km.ScrollViewportRight,
-		km.PrevProject,
-		km.NextProject,
-		km.CreateProject,
-		km.DeleteProject,
-		km.ToggleView,
-		km.MoveTaskToProject,
-		km.ShowHelp,
-		km.Suspend,
-		km.Quit,
+		km.Tasks.AddTask,
+		km.Tasks.EditTask,
+		km.Tasks.DeleteTask,
+		km.Tasks.ViewTask,
+		km.Tasks.EditLabels,
+		km.Tasks.EditPriority,
+		km.Tasks.EditAssignee,
+		km.Tasks.EditEstimate,
+		km.Tasks.EditDueDate,
+		km.Tasks.EditType,
+		km.Tasks.EditParentTask,
+		km.Tasks.EditChildTask,
+		km.Tasks.MoveTaskToProject,
+		km.Kanban.CreateColumn,
+		km.Kanban.RenameColumn,
+		km.Kanban.DeleteColumn,
+		km.Kanban.MoveTaskLeft,
+		km.Kanban.MoveTaskRight,
+		km.Kanban.MoveTaskUp,
+		km.Kanban.MoveTaskDown,
+		km.Navigation.MoveLeft,
+		km.Navigation.MoveRight,
+		km.Navigation.MoveUp,
+		km.Navigation.MoveDown,
+		km.Navigation.ScrollViewportLeft,
+		km.Navigation.ScrollViewportRight,
+		km.Navigation.PrevProject,
+		km.Navigation.NextProject,
+		km.Projects.CreateProject,
+		km.Projects.EditProject,
+		km.Projects.DeleteProject,
+		km.General.ToggleView,
+		km.General.Search,
+		km.General.FilterBar,
+		km.Forms.SaveForm,
+		km.Forms.OpenCommentsView,
+		km.Forms.RefreshGitData,
+		km.Forms.EditLabels,
+		km.Forms.EditParentTask,
+		km.Forms.EditChildTask,
+		km.Forms.EditPriority,
+		km.Forms.EditType,
+		km.Forms.EditAssignee,
+		km.Forms.EditEstimate,
+		km.Forms.EditDueDate,
+		km.Forms.ShowHelp,
+		km.General.ShowHelp,
+		km.General.ConnectRemote,
+		km.General.Suspend,
+		km.General.Quit,
 	)
 }
 
@@ -422,12 +471,13 @@ func (m Model) renderCommentFormLayer() *lipgloss.Layer {
 
 // renderTaskFormHelpLayer renders the task form keyboard shortcuts help screen as a layer
 func (m Model) renderTaskFormHelpLayer() *lipgloss.Layer {
-	helpContent := `TASK FORM - Keyboard Shortcuts
+	km := m.Config.KeyMappings
+	helpContent := fmt.Sprintf(`TASK FORM - Keyboard Shortcuts
 
 FORM NAVIGATION
   Tab             Navigate between form fields
   Shift+Tab       Navigate backwards
-  Ctrl+S          Save task and close form
+  %-15s Save task and close form
   Esc             Close form (will prompt if unsaved)
 
 TEXT EDITING (Title/Description)
@@ -444,21 +494,34 @@ COMMENTS SECTION
   Tab/Shift+Tab   Return to form fields
 
 QUICK ACTIONS
-  Ctrl+N          Create new comment
-  Ctrl+L          Manage labels
-  Ctrl+P          Select parent tasks
-  Ctrl+C          Select child tasks
-  Ctrl+R          Change priority
-  Ctrl+T          Change task type
-  Ctrl+A          Change assignee
-  Ctrl+E          Change estimate
-  Ctrl+D          Set due date
+  %-15s Create new comment
+  %-15s Manage labels
+  %-15s Select parent tasks
+  %-15s Select child tasks
+  %-15s Change priority
+  %-15s Change task type
+  %-15s Change assignee
+  %-15s Change estimate
+  %-15s Set due date
 
 HELP
-  Ctrl+/          Toggle this help menu
+  %-15s Toggle this help menu
   Esc             Close help menu
 
-Press Ctrl+/ or Esc to close`
+Press %s or Esc to close`,
+		km.Forms.SaveForm,
+		km.Forms.OpenCommentsView,
+		km.Forms.EditLabels,
+		km.Forms.EditParentTask,
+		km.Forms.EditChildTask,
+		km.Forms.EditPriority,
+		km.Forms.EditType,
+		km.Forms.EditAssignee,
+		km.Forms.EditEstimate,
+		km.Forms.EditDueDate,
+		km.Forms.ShowHelp,
+		km.Forms.ShowHelp,
+	)
 
 	helpBox := components.HelpBoxStyle.
 		Width(m.UIState.Width() * 3 / 8).


### PR DESCRIPTION
Reorganize flat KeyMappings struct into 7 nested sub-structs (navigation, tasks, kanban, projects, forms, pickers, general) so all keybindings come from config. Add form-specific ctrl+ shortcuts to FormKeys to avoid conflicting with text input. Rename navigation keys from prev_column/ next_column/prev_task/next_task to move_left/right/up/down since they are used across pickers, filter bar, and other contexts. Add example_config.yaml with all defaults for easy user setup.

## Checklist
- [x] Read `CONTRIBUTING.md`
- [x] Ran tests (`go test ./... -race`) locally
- [x] Formatted and linted with `gofmt -w .` and `golangci-lint run ./...` respectively
- [x] Added tests if necessary (significant changes/complex logic)
- [x] Updated documentation if applicable
- [x] Updated `README.md` if applicable

## Summary
<!--
What does this PR change and/or fix? 
Examples:
Closes: 54
Fixes: 67
-->
Closes: #110 