### PR TITLE
fix: respect active filters when reloading tasks after create/update

### DIFF
--- a/internal/tui/search_persistence_test.go
+++ b/internal/tui/search_persistence_test.go
@@ -338,3 +338,174 @@ func TestUnit_SearchPersistence_EmptySearchQueryDoesNotFilter(t *testing.T) {
 	assert.Equal(t, 0, svc.Task.CallCount("GetTaskSummariesWithFilters"),
 		"should NOT use filtered query when search query is empty")
 }
+
+// TestUnit_SearchPersistence_CreateTaskRespectsActiveFilters verifies that
+// creating a new task reloads with GetTaskSummariesWithFilters when filters are active.
+func TestUnit_SearchPersistence_CreateTaskRespectsActiveFilters(t *testing.T) {
+	t.Parallel()
+	svc := NewDefaultMockServices()
+
+	svc.Project.GetAllProjectsResult = []*models.Project{
+		{ID: 1, Name: "Alpha"},
+	}
+	svc.Column.GetColumnsByProjectResult = []*models.Column{
+		{ID: 10, Name: "Todo", ProjectID: 1},
+	}
+	svc.Task.GetTaskSummariesByProjectResult = make(map[int][]*models.TaskSummary)
+	svc.Task.GetTaskSummariesWithFiltersResult = map[int][]*models.TaskSummary{
+		10: {{ID: 99, Title: "Filtered task", ColumnID: 10, Position: 0, Labels: []*models.Label{}, PriorityColor: "#FF0000"}},
+	}
+	svc.Task.CreateTaskResult = &models.Task{ID: 50, Title: "New task"}
+
+	m := SetupTestModelWithMocks(t, svc)
+	m.UIState.SetWidth(120)
+	m.UIState.Height = 40
+
+	// Activate a search filter before creating a task
+	m.UI.Filter.SearchQuery = "bug"
+
+	initialFilteredCalls := svc.Task.CallCount("GetTaskSummariesWithFilters")
+	initialUnfilteredCalls := svc.Task.CallCount("GetTaskSummariesByProject")
+
+	// Create a task
+	m.createNewTaskWithLabelsAndRelationships(taskFormValues{
+		title:       "New task",
+		description: "A new task",
+		confirm:     true,
+	})
+
+	assert.Greater(t, svc.Task.CallCount("GetTaskSummariesWithFilters"), initialFilteredCalls,
+		"createNewTask should use filtered query when search is active")
+	assert.Equal(t, initialUnfilteredCalls, svc.Task.CallCount("GetTaskSummariesByProject"),
+		"createNewTask should NOT call unfiltered query when search is active")
+}
+
+// TestUnit_SearchPersistence_CreateTaskWithoutFiltersUsesUnfiltered verifies that
+// creating a task without active filters uses the unfiltered query.
+func TestUnit_SearchPersistence_CreateTaskWithoutFiltersUsesUnfiltered(t *testing.T) {
+	t.Parallel()
+	svc := NewDefaultMockServices()
+
+	svc.Project.GetAllProjectsResult = []*models.Project{
+		{ID: 1, Name: "Alpha"},
+	}
+	svc.Column.GetColumnsByProjectResult = []*models.Column{
+		{ID: 10, Name: "Todo", ProjectID: 1},
+	}
+	svc.Task.GetTaskSummariesByProjectResult = make(map[int][]*models.TaskSummary)
+	svc.Task.CreateTaskResult = &models.Task{ID: 50, Title: "New task"}
+
+	m := SetupTestModelWithMocks(t, svc)
+	m.UIState.SetWidth(120)
+	m.UIState.Height = 40
+
+	// No filters active
+	initialUnfilteredCalls := svc.Task.CallCount("GetTaskSummariesByProject")
+
+	m.createNewTaskWithLabelsAndRelationships(taskFormValues{
+		title:       "New task",
+		description: "A new task",
+		confirm:     true,
+	})
+
+	assert.Greater(t, svc.Task.CallCount("GetTaskSummariesByProject"), initialUnfilteredCalls,
+		"createNewTask should use unfiltered query when no filters are active")
+	assert.Equal(t, 0, svc.Task.CallCount("GetTaskSummariesWithFilters"),
+		"createNewTask should NOT call filtered query when no filters are active")
+}
+
+// TestUnit_SearchPersistence_UpdateTaskRespectsActiveFilters verifies that
+// updating an existing task reloads with GetTaskSummariesWithFilters when filters are active.
+func TestUnit_SearchPersistence_UpdateTaskRespectsActiveFilters(t *testing.T) {
+	t.Parallel()
+	svc := NewDefaultMockServices()
+
+	svc.Project.GetAllProjectsResult = []*models.Project{
+		{ID: 1, Name: "Alpha"},
+	}
+	svc.Column.GetColumnsByProjectResult = []*models.Column{
+		{ID: 10, Name: "Todo", ProjectID: 1},
+	}
+	svc.Task.GetTaskSummariesByProjectResult = make(map[int][]*models.TaskSummary)
+	svc.Task.GetTaskSummariesWithFiltersResult = map[int][]*models.TaskSummary{
+		10: {{ID: 1, Title: "Filtered task", ColumnID: 10, Position: 0, Labels: []*models.Label{}, PriorityColor: "#FF0000"}},
+	}
+	svc.Task.GetTaskDetailResult = &models.TaskDetail{
+		ID:     1,
+		Title:  "Existing task",
+		Labels: []*models.Label{},
+	}
+
+	m := SetupTestModelWithMocks(t, svc)
+	m.UIState.SetWidth(120)
+	m.UIState.Height = 40
+	m.Forms.Form.EditingTaskID = 1
+
+	// Activate a search filter before updating a task
+	m.UI.Filter.SearchQuery = "bug"
+
+	initialFilteredCalls := svc.Task.CallCount("GetTaskSummariesWithFilters")
+	initialUnfilteredCalls := svc.Task.CallCount("GetTaskSummariesByProject")
+
+	m.updateExistingTaskWithLabelsAndRelationships(taskFormValues{
+		title:       "Updated task",
+		description: "Updated description",
+		confirm:     true,
+	})
+
+	assert.Greater(t, svc.Task.CallCount("GetTaskSummariesWithFilters"), initialFilteredCalls,
+		"updateExistingTask should use filtered query when search is active")
+	assert.Equal(t, initialUnfilteredCalls, svc.Task.CallCount("GetTaskSummariesByProject"),
+		"updateExistingTask should NOT call unfiltered query when search is active")
+}
+
+// TestUnit_SearchPersistence_CreateTaskRespectsFieldFilters verifies that
+// creating a task respects non-search filters (e.g. priority, label filters).
+func TestUnit_SearchPersistence_CreateTaskRespectsFieldFilters(t *testing.T) {
+	t.Parallel()
+	svc := NewDefaultMockServices()
+
+	svc.Project.GetAllProjectsResult = []*models.Project{
+		{ID: 1, Name: "Alpha"},
+	}
+	svc.Column.GetColumnsByProjectResult = []*models.Column{
+		{ID: 10, Name: "Todo", ProjectID: 1},
+	}
+	svc.Task.GetTaskSummariesByProjectResult = make(map[int][]*models.TaskSummary)
+	svc.Task.GetTaskSummariesWithFiltersResult = make(map[int][]*models.TaskSummary)
+	svc.Task.CreateTaskResult = &models.Task{ID: 50, Title: "New task"}
+
+	m := SetupTestModelWithMocks(t, svc)
+	m.UIState.SetWidth(120)
+	m.UIState.Height = 40
+
+	// Activate a priority filter (no search query)
+	priorityID := 2
+	m.UI.Filter.PriorityID = &priorityID
+
+	initialFilteredCalls := svc.Task.CallCount("GetTaskSummariesWithFilters")
+	initialUnfilteredCalls := svc.Task.CallCount("GetTaskSummariesByProject")
+
+	m.createNewTaskWithLabelsAndRelationships(taskFormValues{
+		title:       "New task",
+		description: "A new task",
+		confirm:     true,
+	})
+
+	assert.Greater(t, svc.Task.CallCount("GetTaskSummariesWithFilters"), initialFilteredCalls,
+		"createNewTask should use filtered query when priority filter is active")
+	assert.Equal(t, initialUnfilteredCalls, svc.Task.CallCount("GetTaskSummariesByProject"),
+		"createNewTask should NOT call unfiltered query when priority filter is active")
+
+	// Verify the filter params included the priority
+	calls := svc.Task.GetCalls()
+	for i := len(calls) - 1; i >= 0; i-- {
+		if calls[i].Method == "GetTaskSummariesWithFilters" {
+			params, ok := calls[i].Args["params"].(tasksvc.TaskFilterParams)
+			require.True(t, ok, "expected TaskFilterParams in call args")
+			require.NotNil(t, params.PriorityID, "expected PriorityID to be set")
+			assert.Equal(t, 2, *params.PriorityID, "PriorityID should match active filter")
+			break
+		}
+	}
+}

--- a/internal/tui/update_forms.go
+++ b/internal/tui/update_forms.go
@@ -37,11 +37,11 @@ func (m Model) extractTaskFormValues() taskFormValues {
 }
 
 // createNewTaskWithLabelsAndRelationships creates a new task, sets labels, and applies parent/child relationships
-func (m *Model) createNewTaskWithLabelsAndRelationships(values taskFormValues) {
+func (m *Model) createNewTaskWithLabelsAndRelationships(values taskFormValues) tea.Cmd {
 	currentCol := m.getCurrentColumn()
 	if currentCol == nil {
 		m.UI.Notification.Add(state.LevelError, "No column selected")
-		return
+		return nil
 	}
 
 	// Create context for database operations
@@ -64,7 +64,6 @@ func (m *Model) createNewTaskWithLabelsAndRelationships(values taskFormValues) {
 		}
 	}
 
-	// 1. Create the task with all data in one call
 	task, err := m.App.TaskService.CreateTask(ctx, taskService.CreateTaskRequest{
 		Title:       values.title,
 		Description: values.description,
@@ -80,29 +79,31 @@ func (m *Model) createNewTaskWithLabelsAndRelationships(values taskFormValues) {
 	if err != nil {
 		slog.Error("failed to creating task", "error", err)
 		m.UI.Notification.Add(state.LevelError, "Error creating task")
-		return
+		return nil
 	}
 
-	// 2. Apply parent relationships with correct relation types
 	m.applyParentRelationships(ctx, task.ID)
-
-	// 3. Apply child relationships with correct relation types
 	m.applyChildRelationships(ctx, task.ID)
 
-	// 4. Reload all tasks for the project to keep state consistent
 	project := m.getCurrentProject()
 	if project != nil {
-		tasksByColumn, err := m.App.TaskService.GetTaskSummariesByProject(ctx, project.ID)
+		tasksByColumn, err := m.fetchTasksForCurrentProject(ctx, project.ID)
 		if err != nil {
 			slog.Error("failed to reloading tasks", "error", err)
 		} else {
 			m.AppState.SetTasks(tasksByColumn)
 		}
 	}
+
+	// Notify user if the new task is hidden by active filters
+	if m.UI.Filter.HasAnyFilter() {
+		return m.addNotification(state.LevelWarning, "Task created but hidden by active filters")
+	}
+	return nil
 }
 
 // updateExistingTaskWithLabelsAndRelationships updates task, labels, and parent/child relationships
-func (m *Model) updateExistingTaskWithLabelsAndRelationships(values taskFormValues) {
+func (m *Model) updateExistingTaskWithLabelsAndRelationships(values taskFormValues) tea.Cmd {
 	// create context for database operations
 	ctx, cancel := m.DBContext()
 	defer cancel()
@@ -124,7 +125,7 @@ func (m *Model) updateExistingTaskWithLabelsAndRelationships(values taskFormValu
 	if err != nil {
 		slog.Error("failed to updating task", "error", err)
 		m.UI.Notification.Add(state.LevelError, "Error updating task")
-		return
+		return nil
 	}
 
 	// update labels - need to handle this through detaching old and attaching new
@@ -168,16 +169,22 @@ func (m *Model) updateExistingTaskWithLabelsAndRelationships(values taskFormValu
 
 	m.syncChildRelationships(ctx, taskID)
 
-	// reload all tasks for the project to keep state consistent
+	// reload tasks respecting active filters
 	project := m.getCurrentProject()
 	if project != nil {
-		tasksByColumn, err := m.App.TaskService.GetTaskSummariesByProject(ctx, project.ID)
+		tasksByColumn, err := m.fetchTasksForCurrentProject(ctx, project.ID)
 		if err != nil {
 			slog.Error("failed to reloading tasks", "error", err)
 		} else {
 			m.AppState.SetTasks(tasksByColumn)
 		}
 	}
+
+	// Notify user if the updated task is hidden by active filters
+	if m.UI.Filter.HasAnyFilter() {
+		return m.addNotification(state.LevelWarning, "Task updated but hidden by active filters")
+	}
+	return nil
 }
 
 // applyParentRelationships applies parent relationships from ParentPickerState to a task
@@ -323,8 +330,8 @@ type formConfig struct {
 	form       *huh.Form
 	setForm    func(*huh.Form)
 	clearForm  func()
-	onComplete func() // Called when form completes successfully
-	confirmPtr *bool  // Pointer to confirmation field for quick save
+	onComplete func() tea.Cmd // Called when form completes successfully, may return a cmd (e.g. notification)
+	confirmPtr *bool          // Pointer to confirmation field for quick save
 }
 
 // handleFormUpdate processes form messages generically
@@ -341,15 +348,19 @@ func (m Model) handleFormUpdate(msg tea.Msg, cfg formConfig) (tea.Model, tea.Cmd
 	// Check completion
 	if cfg.form.State == huh.StateCompleted {
 		modeBeforeComplete := m.UIState.Mode
-		cfg.onComplete()
+		completeCmd := cfg.onComplete()
 
 		if m.UIState.Mode != modeBeforeComplete {
-			return m, nil
+			return m, completeCmd
 		}
 
 		m.UIState.Mode = state.NormalMode
 		cfg.setForm(nil)
 		cfg.clearForm()
+
+		if completeCmd != nil {
+			return m, tea.Batch(tea.ClearScreen, completeCmd)
+		}
 		return m, tea.ClearScreen
 	}
 
@@ -376,13 +387,16 @@ func (m Model) handleFormSave(cfg formConfig) (tea.Model, tea.Cmd) {
 	cfg.form.State = huh.StateCompleted
 
 	// Trigger the save logic
-	cfg.onComplete()
+	completeCmd := cfg.onComplete()
 
 	// Clean up and return to normal mode
 	m.UIState.Mode = state.NormalMode
 	cfg.setForm(nil)
 	cfg.clearForm()
 
+	if completeCmd != nil {
+		return m, tea.Batch(tea.ClearScreen, completeCmd)
+	}
 	return m, tea.ClearScreen
 }
 
@@ -524,18 +538,18 @@ func (m Model) updateTaskForm(msg tea.Msg) (tea.Model, tea.Cmd) {
 					m.Forms.Form.ClearTaskForm()
 					m.Forms.Form.EditingTaskID = 0
 				},
-				onComplete: func() {
+				onComplete: func() tea.Cmd {
 					values := m.extractTaskFormValues()
 					if !values.confirm {
-						return
+						return nil
 					}
 					if values.title != "" {
 						if m.Forms.Form.EditingTaskID == 0 {
-							m.createNewTaskWithLabelsAndRelationships(values)
-						} else {
-							m.updateExistingTaskWithLabelsAndRelationships(values)
+							return m.createNewTaskWithLabelsAndRelationships(values)
 						}
+						return m.updateExistingTaskWithLabelsAndRelationships(values)
 					}
+					return nil
 				},
 				confirmPtr: &m.Forms.Form.FormConfirm,
 			})
@@ -552,22 +566,22 @@ func (m Model) updateTaskForm(msg tea.Msg) (tea.Model, tea.Cmd) {
 			m.Forms.Form.ClearTaskForm()
 			m.Forms.Form.EditingTaskID = 0
 		},
-		onComplete: func() {
+		onComplete: func() tea.Cmd {
 			values := m.extractTaskFormValues()
 
 			// Form submitted - check confirmation and save the task
 			if !values.confirm {
 				// User selected "No" on confirmation
-				return
+				return nil
 			}
 
 			if values.title != "" {
 				if m.Forms.Form.EditingTaskID == 0 {
-					m.createNewTaskWithLabelsAndRelationships(values)
-				} else {
-					m.updateExistingTaskWithLabelsAndRelationships(values)
+					return m.createNewTaskWithLabelsAndRelationships(values)
 				}
+				return m.updateExistingTaskWithLabelsAndRelationships(values)
 			}
+			return nil
 		},
 		confirmPtr: &m.Forms.Form.FormConfirm,
 	})
@@ -607,8 +621,9 @@ func (m Model) updateProjectForm(msg tea.Msg) (tea.Model, tea.Cmd) {
 				clearForm: func() {
 					m.Forms.Form.ClearProjectForm()
 				},
-				onComplete: func() {
+				onComplete: func() tea.Cmd {
 					m.submitProjectForm()
+					return nil
 				},
 				confirmPtr: &m.Forms.Form.FormProjectConfirm,
 			})
@@ -626,8 +641,9 @@ func (m Model) updateProjectForm(msg tea.Msg) (tea.Model, tea.Cmd) {
 		clearForm: func() {
 			m.Forms.Form.ClearProjectForm()
 		},
-		onComplete: func() {
+		onComplete: func() tea.Cmd {
 			m.submitProjectForm()
+			return nil
 		},
 	})
 }
@@ -795,12 +811,12 @@ func (m Model) updateColumnForm(msg tea.Msg) (tea.Model, tea.Cmd) {
 		clearForm: func() {
 			m.Forms.Form.ClearColumnForm()
 		},
-		onComplete: func() {
+		onComplete: func() tea.Cmd {
 			// Read values from form state (forms update pointers in place)
 			name := strings.TrimSpace(m.Forms.Form.FormColumnName)
 
 			if name == "" {
-				return
+				return nil
 			}
 
 			ctx, cancel := m.DBContext()
@@ -811,7 +827,7 @@ func (m Model) updateColumnForm(msg tea.Msg) (tea.Model, tea.Cmd) {
 				project := m.getCurrentProject()
 				if project == nil {
 					m.UI.Notification.Add(state.LevelError, "No project selected")
-					return
+					return nil
 				}
 
 				_, err := m.App.ColumnService.CreateColumn(ctx, columnService.CreateColumnRequest{
@@ -822,7 +838,7 @@ func (m Model) updateColumnForm(msg tea.Msg) (tea.Model, tea.Cmd) {
 				if err != nil {
 					slog.Error("failed to creating column", "error", err)
 					m.UI.Notification.Add(state.LevelError, "Error creating column")
-					return
+					return nil
 				}
 
 				// Reload columns
@@ -833,12 +849,13 @@ func (m Model) updateColumnForm(msg tea.Msg) (tea.Model, tea.Cmd) {
 				if err != nil {
 					slog.Error("failed to renaming column", "error", err)
 					m.UI.Notification.Add(state.LevelError, "Error renaming column")
-					return
+					return nil
 				}
 
 				// Reload columns
 				m.reloadCurrentProject()
 			}
+			return nil
 		},
 		confirmPtr: nil, // Column forms don't have confirmation field
 	})
@@ -890,12 +907,12 @@ func (m Model) updateCommentForm(msg tea.Msg) (tea.Model, tea.Cmd) {
 		clearForm: func() {
 			m.Forms.Form.ClearCommentForm()
 		},
-		onComplete: func() {
+		onComplete: func() tea.Cmd {
 			// Read values from form state (forms update pointers in place)
 			message := strings.TrimSpace(m.Forms.Form.FormCommentMessage)
 
 			if message == "" {
-				return
+				return nil
 			}
 
 			ctx, cancel := m.DBContext()
@@ -906,7 +923,7 @@ func (m Model) updateCommentForm(msg tea.Msg) (tea.Model, tea.Cmd) {
 				taskID := m.Forms.Form.EditingTaskID
 				if taskID == 0 {
 					m.UI.Notification.Add(state.LevelError, "No task selected")
-					return
+					return nil
 				}
 
 				_, err := m.App.TaskService.CreateComment(ctx, taskService.CreateCommentRequest{
@@ -917,7 +934,7 @@ func (m Model) updateCommentForm(msg tea.Msg) (tea.Model, tea.Cmd) {
 				if err != nil {
 					slog.Error("failed to creating comment", "error", err)
 					m.UI.Notification.Add(state.LevelError, "Error creating comment")
-					return
+					return nil
 				}
 
 				m.UI.Notification.Add(state.LevelInfo, "Comment added")
@@ -930,7 +947,7 @@ func (m Model) updateCommentForm(msg tea.Msg) (tea.Model, tea.Cmd) {
 				if err != nil {
 					slog.Error("failed to updating comment", "error", err)
 					m.UI.Notification.Add(state.LevelError, "Error updating comment")
-					return
+					return nil
 				}
 
 				m.UI.Notification.Add(state.LevelInfo, "Comment updated")
@@ -960,6 +977,7 @@ func (m Model) updateCommentForm(msg tea.Msg) (tea.Model, tea.Cmd) {
 			} else {
 				m.UIState.Mode = state.TicketFormMode
 			}
+			return nil
 		},
 		confirmPtr: nil, // Comment forms don't have confirmation field
 	})


### PR DESCRIPTION
## Summary

- Task creation and editing now respect active filter predicates (search, priority, type, assignee, labels) when reloading the task list, instead of bypassing them with an unfiltered query
- Shows a warning notification ("Task created/updated but hidden by active filters") when the saved task won't be visible due to active filters
- Changes `formConfig.onComplete` from `func()` to `func() tea.Cmd` to allow form completion handlers to return commands (e.g. notifications)

## Root Cause

`createNewTaskWithLabelsAndRelationships` and `updateExistingTaskWithLabelsAndRelationships` called `GetTaskSummariesByProject` directly instead of `fetchTasksForCurrentProject`, which is the method that checks `HasAnyFilter()` and routes to the filtered query.

## Testing

- 4 new tests in `search_persistence_test.go` covering create/update with and without active filters
- All existing tests pass, `golangci-lint` clean

Closes #121