### PR TITLE
fix: standup generator time zones

### DIFF
--- a/internal/cli/standup/generate.go
+++ b/internal/cli/standup/generate.go
@@ -63,7 +63,9 @@ func runGenerate(cmd *cobra.Command, _ []string) error {
 		weeks = 1
 	}
 
-	now := time.Now()
+	// Use UTC so that query boundaries align with how both SQLite (CURRENT_TIMESTAMP stores
+	// UTC) and PostgreSQL (lib/pq normalises to UTC over the wire) persist timestamps.
+	now := time.Now().UTC()
 	since := ComputeSince(now, days, weeks)
 	until := now
 

--- a/internal/cli/standup/generate_logic.go
+++ b/internal/cli/standup/generate_logic.go
@@ -34,7 +34,9 @@ func GroupLogsByDate(logs []models.StandupLog) []DateGroup {
 	groupMap := map[string][]models.StandupLog{}
 
 	for _, l := range logs {
-		dateKey := l.CreatedAt.Format("2006-01-02")
+		// Use Local() so logs are grouped by the user's local calendar date, not UTC.
+		// Timestamps are stored in UTC but should be displayed in the user's timezone.
+		dateKey := l.CreatedAt.Local().Format("2006-01-02")
 		if _, exists := groupMap[dateKey]; !exists {
 			orderMap[dateKey] = len(orderMap)
 		}
@@ -116,7 +118,7 @@ func FormatGenerateHuman(logs []models.StandupLog, since, until time.Time, color
 	headerStyle := lipgloss.NewStyle().
 		Foreground(lipgloss.Color(colorScheme.Subtle))
 
-	rangeStr := fmt.Sprintf("%s to %s", since.Format("Jan 02, 2006"), until.Format("Jan 02, 2006"))
+	rangeStr := fmt.Sprintf("%s to %s", since.Local().Format("Jan 02, 2006"), until.Local().Format("Jan 02, 2006"))
 	fmt.Fprintf(&out, "%s\n\n", headerStyle.Render(fmt.Sprintf("Standup report (%s) - %d log(s)", rangeStr, len(logs))))
 
 	for i, g := range groups {
@@ -124,7 +126,7 @@ func FormatGenerateHuman(logs []models.StandupLog, since, until time.Time, color
 		out.WriteString("\n")
 
 		for _, l := range g.Logs {
-			timestamp := l.CreatedAt.Format("3:04 PM")
+			timestamp := l.CreatedAt.Local().Format("3:04 PM")
 			idStr := fmt.Sprintf("#%d", l.ID)
 
 			out.WriteString("  ")

--- a/internal/database/adapters/postgres/standup_log_test.go
+++ b/internal/database/adapters/postgres/standup_log_test.go
@@ -1,0 +1,407 @@
+package postgres_test
+
+import (
+	"context"
+	"fmt"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	postgres_adapter "github.com/thenoetrevino/paso/internal/database/adapters/postgres"
+	"github.com/thenoetrevino/paso/internal/database/types"
+	"github.com/thenoetrevino/paso/internal/testing/fixtures"
+)
+
+// TestStandupLogDateRangeQuery_Postgres verifies that the PostgreSQL adapter correctly
+// filters standup logs by a UTC date range.
+//
+// PostgreSQL uses TIMESTAMP WITHOUT TIME ZONE. The lib/pq driver sends time.Time params
+// correctly in wire format and the server handles timezone-aware comparison. However,
+// we still validate that UTC-normalized query bounds correctly bracket stored values.
+//
+// These tests require PostgreSQL to be running (see fixtures.SetupPostgresTestDB).
+// They are skipped automatically when PostgreSQL is unavailable.
+func TestStandupLogDateRangeQuery_Postgres(t *testing.T) {
+	t.Parallel()
+	ctx := context.Background()
+	d := fixtures.PostgresDialect()
+
+	t.Run("UTC range matches logs stored by DEFAULT CURRENT_TIMESTAMP", func(t *testing.T) {
+		t.Parallel()
+		db := fixtures.SetupPostgresTestDB(t)
+		if db == nil {
+			return
+		}
+		adapter := postgres_adapter.New(db)
+		projectID := int64(fixtures.CreateTestProject(t, db, d, "pg-tz-test"))
+
+		insertAt := func(content string, at time.Time) {
+			t.Helper()
+			_, err := db.ExecContext(ctx,
+				"INSERT INTO standup_logs (project_id, content, created_at) VALUES ($1, $2, $3)",
+				projectID, content, at.UTC())
+			require.NoError(t, err)
+		}
+
+		// Log: Feb 23, 2026 at 17:13 UTC (exact timestamp from the bug report)
+		insertAt("finished this and that", time.Date(2026, 2, 23, 17, 13, 2, 0, time.UTC))
+		// Log: Feb 22, 2026 at 10:00 UTC
+		insertAt("previous day log", time.Date(2026, 2, 22, 10, 0, 0, 0, time.UTC))
+		// Log: Feb 15, 2026 at 09:00 UTC — outside the 1-week range
+		insertAt("old log", time.Date(2026, 2, 15, 9, 0, 0, 0, time.UTC))
+
+		// 1 week back from Feb 23 → since Feb 16 00:00 UTC
+		since := time.Date(2026, 2, 16, 0, 0, 0, 0, time.UTC)
+		until := time.Date(2026, 2, 24, 0, 0, 0, 0, time.UTC)
+
+		results, err := adapter.GetStandupLogsByProjectAndDateRange(ctx, types.GetStandupLogsByProjectAndDateRangeParams{
+			ProjectID: projectID,
+			Since:     since,
+			Until:     until,
+		})
+		require.NoError(t, err)
+		require.Len(t, results, 2, "should return both Feb 22 and Feb 23 logs")
+
+		contents := make([]string, len(results))
+		for i, r := range results {
+			contents[i] = r.Content
+		}
+		assert.Contains(t, contents, "finished this and that")
+		assert.Contains(t, contents, "previous day log")
+		assert.NotContains(t, contents, "old log")
+	})
+
+	t.Run("returns empty when range is in the future", func(t *testing.T) {
+		t.Parallel()
+		db := fixtures.SetupPostgresTestDB(t)
+		if db == nil {
+			return
+		}
+		adapter := postgres_adapter.New(db)
+		projectID := int64(fixtures.CreateTestProject(t, db, d, "pg-future"))
+
+		_, err := db.ExecContext(ctx,
+			"INSERT INTO standup_logs (project_id, content, created_at) VALUES ($1, $2, $3)",
+			projectID, "a log", time.Date(2026, 2, 23, 17, 0, 0, 0, time.UTC))
+		require.NoError(t, err)
+
+		results, err := adapter.GetStandupLogsByProjectAndDateRange(ctx, types.GetStandupLogsByProjectAndDateRangeParams{
+			ProjectID: projectID,
+			Since:     time.Date(2027, 1, 1, 0, 0, 0, 0, time.UTC),
+			Until:     time.Date(2027, 1, 8, 0, 0, 0, 0, time.UTC),
+		})
+		require.NoError(t, err)
+		assert.Empty(t, results)
+	})
+
+	t.Run("returns empty when range predates all logs", func(t *testing.T) {
+		t.Parallel()
+		db := fixtures.SetupPostgresTestDB(t)
+		if db == nil {
+			return
+		}
+		adapter := postgres_adapter.New(db)
+		projectID := int64(fixtures.CreateTestProject(t, db, d, "pg-past"))
+
+		_, err := db.ExecContext(ctx,
+			"INSERT INTO standup_logs (project_id, content, created_at) VALUES ($1, $2, $3)",
+			projectID, "a log", time.Date(2026, 2, 23, 17, 0, 0, 0, time.UTC))
+		require.NoError(t, err)
+
+		results, err := adapter.GetStandupLogsByProjectAndDateRange(ctx, types.GetStandupLogsByProjectAndDateRangeParams{
+			ProjectID: projectID,
+			Since:     time.Date(2025, 1, 1, 0, 0, 0, 0, time.UTC),
+			Until:     time.Date(2025, 1, 8, 0, 0, 0, 0, time.UTC),
+		})
+		require.NoError(t, err)
+		assert.Empty(t, results)
+	})
+
+	t.Run("until boundary is exclusive", func(t *testing.T) {
+		t.Parallel()
+		db := fixtures.SetupPostgresTestDB(t)
+		if db == nil {
+			return
+		}
+		adapter := postgres_adapter.New(db)
+		projectID := int64(fixtures.CreateTestProject(t, db, d, "pg-until-exclusive"))
+
+		logAt := time.Date(2026, 2, 23, 17, 13, 2, 0, time.UTC)
+		_, err := db.ExecContext(ctx,
+			"INSERT INTO standup_logs (project_id, content, created_at) VALUES ($1, $2, $3)",
+			projectID, "test", logAt)
+		require.NoError(t, err)
+
+		// until = exactly the log timestamp — should NOT be included (<, not <=)
+		results, err := adapter.GetStandupLogsByProjectAndDateRange(ctx, types.GetStandupLogsByProjectAndDateRangeParams{
+			ProjectID: projectID,
+			Since:     time.Date(2026, 2, 23, 0, 0, 0, 0, time.UTC),
+			Until:     logAt,
+		})
+		require.NoError(t, err)
+		assert.Empty(t, results, "log at exact 'until' boundary should be excluded")
+	})
+
+	t.Run("since boundary is inclusive", func(t *testing.T) {
+		t.Parallel()
+		db := fixtures.SetupPostgresTestDB(t)
+		if db == nil {
+			return
+		}
+		adapter := postgres_adapter.New(db)
+		projectID := int64(fixtures.CreateTestProject(t, db, d, "pg-since-inclusive"))
+
+		logAt := time.Date(2026, 2, 22, 10, 0, 0, 0, time.UTC)
+		_, err := db.ExecContext(ctx,
+			"INSERT INTO standup_logs (project_id, content, created_at) VALUES ($1, $2, $3)",
+			projectID, "boundary log", logAt)
+		require.NoError(t, err)
+
+		// since = exactly the log timestamp — should be included (>=)
+		results, err := adapter.GetStandupLogsByProjectAndDateRange(ctx, types.GetStandupLogsByProjectAndDateRangeParams{
+			ProjectID: projectID,
+			Since:     logAt,
+			Until:     time.Date(2026, 2, 23, 0, 0, 0, 0, time.UTC),
+		})
+		require.NoError(t, err)
+		require.Len(t, results, 1)
+		assert.Equal(t, "boundary log", results[0].Content)
+	})
+
+	t.Run("only returns logs for the specified project", func(t *testing.T) {
+		t.Parallel()
+		db := fixtures.SetupPostgresTestDB(t)
+		if db == nil {
+			return
+		}
+		adapter := postgres_adapter.New(db)
+		projectID := int64(fixtures.CreateTestProject(t, db, d, "pg-project-filter"))
+		otherProjectID := int64(fixtures.CreateTestProject(t, db, d, "pg-other-project"))
+
+		logAt := time.Date(2026, 2, 23, 12, 0, 0, 0, time.UTC)
+		_, err := db.ExecContext(ctx,
+			"INSERT INTO standup_logs (project_id, content, created_at) VALUES ($1, $2, $3)",
+			projectID, "my log", logAt)
+		require.NoError(t, err)
+		_, err = db.ExecContext(ctx,
+			"INSERT INTO standup_logs (project_id, content, created_at) VALUES ($1, $2, $3)",
+			otherProjectID, "other log", logAt)
+		require.NoError(t, err)
+
+		results, err := adapter.GetStandupLogsByProjectAndDateRange(ctx, types.GetStandupLogsByProjectAndDateRangeParams{
+			ProjectID: projectID,
+			Since:     time.Date(2026, 2, 16, 0, 0, 0, 0, time.UTC),
+			Until:     time.Date(2026, 2, 24, 0, 0, 0, 0, time.UTC),
+		})
+		require.NoError(t, err)
+		require.Len(t, results, 1)
+		assert.Equal(t, projectID, results[0].ProjectID)
+	})
+
+	t.Run("results are ordered newest first", func(t *testing.T) {
+		t.Parallel()
+		db := fixtures.SetupPostgresTestDB(t)
+		if db == nil {
+			return
+		}
+		adapter := postgres_adapter.New(db)
+		projectID := int64(fixtures.CreateTestProject(t, db, d, "pg-ordering"))
+
+		for _, entry := range []struct {
+			content string
+			at      time.Time
+		}{
+			{"oldest", time.Date(2026, 2, 20, 8, 0, 0, 0, time.UTC)},
+			{"middle", time.Date(2026, 2, 21, 10, 0, 0, 0, time.UTC)},
+			{"newest", time.Date(2026, 2, 23, 17, 0, 0, 0, time.UTC)},
+		} {
+			_, err := db.ExecContext(ctx,
+				"INSERT INTO standup_logs (project_id, content, created_at) VALUES ($1, $2, $3)",
+				projectID, entry.content, entry.at)
+			require.NoError(t, err)
+		}
+
+		results, err := adapter.GetStandupLogsByProjectAndDateRange(ctx, types.GetStandupLogsByProjectAndDateRangeParams{
+			ProjectID: projectID,
+			Since:     time.Date(2026, 2, 16, 0, 0, 0, 0, time.UTC),
+			Until:     time.Date(2026, 2, 24, 0, 0, 0, 0, time.UTC),
+		})
+		require.NoError(t, err)
+		require.Len(t, results, 3)
+		assert.Equal(t, "newest", results[0].Content)
+		assert.Equal(t, "middle", results[1].Content)
+		assert.Equal(t, "oldest", results[2].Content)
+	})
+
+	t.Run("returned created_at is correct UTC time", func(t *testing.T) {
+		t.Parallel()
+		db := fixtures.SetupPostgresTestDB(t)
+		if db == nil {
+			return
+		}
+		adapter := postgres_adapter.New(db)
+		projectID := int64(fixtures.CreateTestProject(t, db, d, "pg-created-at-utc"))
+
+		logAt := time.Date(2026, 2, 23, 17, 13, 2, 0, time.UTC)
+		_, err := db.ExecContext(ctx,
+			"INSERT INTO standup_logs (project_id, content, created_at) VALUES ($1, $2, $3)",
+			projectID, "test", logAt)
+		require.NoError(t, err)
+
+		results, err := adapter.GetStandupLogsByProjectAndDateRange(ctx, types.GetStandupLogsByProjectAndDateRangeParams{
+			ProjectID: projectID,
+			Since:     time.Date(2026, 2, 23, 17, 0, 0, 0, time.UTC),
+			Until:     time.Date(2026, 2, 23, 18, 0, 0, 0, time.UTC),
+		})
+		require.NoError(t, err)
+		require.Len(t, results, 1)
+
+		got := results[0].CreatedAt
+		require.True(t, got.Valid)
+		utc := got.Time.UTC()
+		assert.Equal(t, 2026, utc.Year())
+		assert.Equal(t, time.February, utc.Month())
+		assert.Equal(t, 23, utc.Day())
+		assert.Equal(t, 17, utc.Hour())
+		assert.Equal(t, 13, utc.Minute())
+		assert.Equal(t, 2, utc.Second())
+	})
+}
+
+// TestStandupLogDateRangeQuery_Postgres_TimezoneEdgeCases tests UTC boundary edge cases
+// for PostgreSQL. The key invariant: UTC-normalized since/until must correctly bracket
+// values stored via DEFAULT CURRENT_TIMESTAMP (server-local time in Postgres TIMESTAMP).
+//
+// Note: PostgreSQL TIMESTAMP WITHOUT TIME ZONE stores values in the server's local time,
+// but the lib/pq driver automatically handles conversion to/from UTC for time.Time params.
+func TestStandupLogDateRangeQuery_Postgres_TimezoneEdgeCases(t *testing.T) {
+	t.Parallel()
+	ctx := context.Background()
+	d := fixtures.PostgresDialect()
+
+	t.Run("UTC midnight boundaries span the full day", func(t *testing.T) {
+		t.Parallel()
+		db := fixtures.SetupPostgresTestDB(t)
+		if db == nil {
+			return
+		}
+		adapter := postgres_adapter.New(db)
+		projectID := int64(fixtures.CreateTestProject(t, db, d, "pg-midnight-span"))
+
+		// User in UTC-6: logs at 5:13 PM local (CST) = 23:13 UTC on Feb 22
+		_, err := db.ExecContext(ctx,
+			"INSERT INTO standup_logs (project_id, content, created_at) VALUES ($1, $2, $3)",
+			projectID, "evening local time", time.Date(2026, 2, 22, 23, 13, 0, 0, time.UTC))
+		require.NoError(t, err)
+		// User in UTC+9 (JST): logs at 8 AM local Feb 23 = Feb 22 23:00 UTC
+		_, err = db.ExecContext(ctx,
+			"INSERT INTO standup_logs (project_id, content, created_at) VALUES ($1, $2, $3)",
+			projectID, "morning JST same UTC day", time.Date(2026, 2, 22, 23, 0, 0, 0, time.UTC))
+		require.NoError(t, err)
+
+		since := time.Date(2026, 2, 22, 0, 0, 0, 0, time.UTC)
+		until := time.Date(2026, 2, 23, 0, 0, 0, 0, time.UTC)
+
+		results, err := adapter.GetStandupLogsByProjectAndDateRange(ctx, types.GetStandupLogsByProjectAndDateRangeParams{
+			ProjectID: projectID,
+			Since:     since,
+			Until:     until,
+		})
+		require.NoError(t, err)
+		assert.Len(t, results, 2, "both logs at 23:00 and 23:13 UTC on Feb 22 should be found")
+	})
+
+	t.Run("log at 23:59:59 UTC is within same-day UTC range", func(t *testing.T) {
+		t.Parallel()
+		db := fixtures.SetupPostgresTestDB(t)
+		if db == nil {
+			return
+		}
+		adapter := postgres_adapter.New(db)
+		projectID := int64(fixtures.CreateTestProject(t, db, d, "pg-late-night-utc"))
+
+		_, err := db.ExecContext(ctx,
+			"INSERT INTO standup_logs (project_id, content, created_at) VALUES ($1, $2, $3)",
+			projectID, "late night log", time.Date(2026, 2, 22, 23, 59, 59, 0, time.UTC))
+		require.NoError(t, err)
+
+		results, err := adapter.GetStandupLogsByProjectAndDateRange(ctx, types.GetStandupLogsByProjectAndDateRangeParams{
+			ProjectID: projectID,
+			Since:     time.Date(2026, 2, 22, 0, 0, 0, 0, time.UTC),
+			Until:     time.Date(2026, 2, 23, 0, 0, 0, 0, time.UTC),
+		})
+		require.NoError(t, err)
+		require.Len(t, results, 1)
+		assert.Equal(t, "late night log", results[0].Content)
+	})
+
+	t.Run("log at midnight UTC is NOT in previous day range", func(t *testing.T) {
+		t.Parallel()
+		db := fixtures.SetupPostgresTestDB(t)
+		if db == nil {
+			return
+		}
+		adapter := postgres_adapter.New(db)
+		projectID := int64(fixtures.CreateTestProject(t, db, d, "pg-midnight-boundary"))
+
+		// Log exactly at Feb 23 00:00:00 UTC — the exclusive 'until' for Feb 22
+		_, err := db.ExecContext(ctx,
+			"INSERT INTO standup_logs (project_id, content, created_at) VALUES ($1, $2, $3)",
+			projectID, "midnight log", time.Date(2026, 2, 23, 0, 0, 0, 0, time.UTC))
+		require.NoError(t, err)
+
+		// Range is Feb 22 only
+		results, err := adapter.GetStandupLogsByProjectAndDateRange(ctx, types.GetStandupLogsByProjectAndDateRangeParams{
+			ProjectID: projectID,
+			Since:     time.Date(2026, 2, 22, 0, 0, 0, 0, time.UTC),
+			Until:     time.Date(2026, 2, 23, 0, 0, 0, 0, time.UTC),
+		})
+		require.NoError(t, err)
+		assert.Empty(t, results, "log at midnight (exclusive 'until') should not appear in Feb 22 range")
+
+		// But it SHOULD appear in the Feb 23 range
+		results, err = adapter.GetStandupLogsByProjectAndDateRange(ctx, types.GetStandupLogsByProjectAndDateRangeParams{
+			ProjectID: projectID,
+			Since:     time.Date(2026, 2, 23, 0, 0, 0, 0, time.UTC),
+			Until:     time.Date(2026, 2, 24, 0, 0, 0, 0, time.UTC),
+		})
+		require.NoError(t, err)
+		require.Len(t, results, 1)
+		assert.Equal(t, "midnight log", results[0].Content)
+	})
+}
+
+// TestStandupLogCreateAndRetrieve_Postgres verifies the round-trip create + retrieve.
+func TestStandupLogCreateAndRetrieve_Postgres(t *testing.T) {
+	t.Parallel()
+
+	db := fixtures.SetupPostgresTestDB(t)
+	if db == nil {
+		return
+	}
+	adapter := postgres_adapter.New(db)
+	ctx := context.Background()
+
+	d := fixtures.PostgresDialect()
+	projectID := int64(fixtures.CreateTestProject(t, db, d, "pg-create-retrieve"))
+
+	before := time.Now().UTC().Truncate(time.Second)
+
+	created, err := adapter.CreateStandupLog(ctx, types.CreateStandupLogParams{
+		ProjectID: projectID,
+		Content:   "test entry",
+	})
+	require.NoError(t, err)
+
+	after := time.Now().UTC().Add(time.Second)
+
+	assert.Equal(t, projectID, created.ProjectID)
+	assert.Equal(t, "test entry", created.Content)
+	require.True(t, created.CreatedAt.Valid, "created_at should be valid (non-NULL)")
+	assert.False(t, created.CreatedAt.Time.IsZero(), "created_at should not be zero")
+
+	utcTime := created.CreatedAt.Time.UTC()
+	assert.True(t, !utcTime.Before(before) && !utcTime.After(after),
+		fmt.Sprintf("created_at (%v) should be between %v and %v", utcTime, before, after))
+}

--- a/internal/database/adapters/sqlite/convert_to.go
+++ b/internal/database/adapters/sqlite/convert_to.go
@@ -279,13 +279,5 @@ func toGeneratedCreateStandupLogParams(t types.CreateStandupLogParams) generated
 	}
 }
 
-func toGeneratedGetStandupLogsByProjectAndDateRangeParams(t types.GetStandupLogsByProjectAndDateRangeParams) generated_sqlite.GetStandupLogsByProjectAndDateRangeParams {
-	return generated_sqlite.GetStandupLogsByProjectAndDateRangeParams{
-		ProjectID:   t.ProjectID,
-		CreatedAt:   sql.NullTime{Time: t.Since, Valid: true},
-		CreatedAt_2: sql.NullTime{Time: t.Until, Valid: true},
-	}
-}
-
 // Suppress unused import warning
 var _ = sql.ErrNoRows

--- a/internal/database/adapters/sqlite/standup_log.go
+++ b/internal/database/adapters/sqlite/standup_log.go
@@ -63,7 +63,7 @@ func (a *Adapter) GetStandupLogsByProjectAndDateRange(ctx context.Context, arg t
 	if err != nil {
 		return nil, err
 	}
-	defer rows.Close()
+	defer func() { _ = rows.Close() }()
 
 	var items []types.StandupLog
 	for rows.Next() {

--- a/internal/database/adapters/sqlite/standup_log.go
+++ b/internal/database/adapters/sqlite/standup_log.go
@@ -2,9 +2,16 @@ package sqlite
 
 import (
 	"context"
+	"database/sql"
 
 	"github.com/thenoetrevino/paso/internal/database/types"
 )
+
+// sqliteDatetimeFormat is the RFC3339 UTC format that the modernc.org/sqlite driver
+// uses internally when storing and comparing datetime values. Using this format for
+// query parameters ensures correct string comparison with values stored via
+// DEFAULT CURRENT_TIMESTAMP (which the driver also normalizes to this format on read).
+const sqliteDatetimeFormat = "2006-01-02T15:04:05Z"
 
 func (a *Adapter) CreateStandupLog(ctx context.Context, arg types.CreateStandupLogParams) (types.StandupLog, error) {
 	result, err := a.queries.CreateStandupLog(ctx, toGeneratedCreateStandupLogParams(arg))
@@ -30,12 +37,56 @@ func (a *Adapter) GetStandupLogsByProject(ctx context.Context, projectID int64) 
 	return types.ConvertSlice(results, fromGeneratedStandupLog), nil
 }
 
+// GetStandupLogsByProjectAndDateRange overrides the generated query to work around a
+// modernc.org/sqlite driver incompatibility: the driver serializes sql.NullTime params
+// as Go's time.Time.String() format ("2006-01-02 17:13:02 +0000 UTC"), which does not
+// compare correctly with datetime values stored by DEFAULT CURRENT_TIMESTAMP (normalized
+// to RFC3339 "2006-01-02T15:04:05Z" by the driver on read). Using pre-formatted RFC3339
+// strings as query parameters ensures consistent string comparison.
 func (a *Adapter) GetStandupLogsByProjectAndDateRange(ctx context.Context, arg types.GetStandupLogsByProjectAndDateRangeParams) ([]types.StandupLog, error) {
-	results, err := a.queries.GetStandupLogsByProjectAndDateRange(ctx, toGeneratedGetStandupLogsByProjectAndDateRangeParams(arg))
+	// Use datetime() on both sides to normalize the comparison. The modernc.org/sqlite
+	// driver applies internal type conversion to datetime-affinity columns that causes
+	// plain string comparison with text parameters to fail even when the strings are
+	// identical. Wrapping both sides with datetime() forces consistent comparison.
+	const query = `
+		select id, project_id, content, created_at
+		from standup_logs
+		where project_id = ?
+		  and datetime(created_at) >= datetime(?)
+		  and datetime(created_at) < datetime(?)
+		order by created_at desc`
+
+	since := arg.Since.UTC().Format(sqliteDatetimeFormat)
+	until := arg.Until.UTC().Format(sqliteDatetimeFormat)
+
+	rows, err := a.db.QueryContext(ctx, query, arg.ProjectID, since, until)
 	if err != nil {
 		return nil, err
 	}
-	return types.ConvertSlice(results, fromGeneratedStandupLog), nil
+	defer rows.Close()
+
+	var items []types.StandupLog
+	for rows.Next() {
+		var id, projectID int64
+		var content string
+		var createdAt sql.NullTime
+		if err := rows.Scan(&id, &projectID, &content, &createdAt); err != nil {
+			return nil, err
+		}
+		items = append(items, types.StandupLog{
+			ID:        id,
+			ProjectID: projectID,
+			Content:   content,
+			CreatedAt: types.FromSQLNullTime(createdAt),
+		})
+	}
+	if err := rows.Close(); err != nil {
+		return nil, err
+	}
+	if err := rows.Err(); err != nil {
+		return nil, err
+	}
+	return items, nil
 }
 
 func (a *Adapter) DeleteStandupLog(ctx context.Context, id int64) error {

--- a/internal/database/adapters/sqlite/standup_log_test.go
+++ b/internal/database/adapters/sqlite/standup_log_test.go
@@ -1,0 +1,405 @@
+package sqlite_test
+
+import (
+	"context"
+	"fmt"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	sqlite_adapter "github.com/thenoetrevino/paso/internal/database/adapters/sqlite"
+	"github.com/thenoetrevino/paso/internal/database/types"
+	"github.com/thenoetrevino/paso/internal/testing/fixtures"
+)
+
+// TestStandupLogDateRangeQuery_SQLite verifies that the SQLite adapter correctly filters
+// standup logs by a UTC date range. This is the core regression test for the timezone
+// mismatch bug where CURRENT_TIMESTAMP stores UTC bare strings but query params were
+// constructed in local time.
+func TestStandupLogDateRangeQuery_SQLite(t *testing.T) {
+	t.Parallel()
+
+	ctx := context.Background()
+	d := fixtures.SQLiteDialect()
+
+	t.Run("UTC range matches UTC-stored logs", func(t *testing.T) {
+		t.Parallel()
+		db := fixtures.SetupTestDB(t)
+		adapter := sqlite_adapter.New(db)
+		projectID := int64(fixtures.CreateTestProject(t, db, d, "tz-test"))
+
+		insertAt := func(content string, at time.Time) {
+			t.Helper()
+			ts := at.UTC().Format("2006-01-02 15:04:05")
+			_, err := db.ExecContext(ctx,
+				"INSERT INTO standup_logs (project_id, content, created_at) VALUES (?, ?, ?)",
+				projectID, content, ts)
+			require.NoError(t, err)
+		}
+
+		// Log: Feb 23, 2026 at 17:13 UTC (the exact timestamp from the bug report)
+		insertAt("finished this and that", time.Date(2026, 2, 23, 17, 13, 2, 0, time.UTC))
+		// Log: Feb 22, 2026 at 10:00 UTC
+		insertAt("previous day log", time.Date(2026, 2, 22, 10, 0, 0, 0, time.UTC))
+		// Log: Feb 15, 2026 at 09:00 UTC — outside the 1-week range
+		insertAt("old log", time.Date(2026, 2, 15, 9, 0, 0, 0, time.UTC))
+
+		// Simulate what generate.go does after the fix: time.Now().UTC() as reference.
+		// 1 week back from Feb 23 = since Feb 16 00:00 UTC.
+		since := time.Date(2026, 2, 16, 0, 0, 0, 0, time.UTC)
+		until := time.Date(2026, 2, 24, 0, 0, 0, 0, time.UTC)
+
+		results, err := adapter.GetStandupLogsByProjectAndDateRange(ctx, types.GetStandupLogsByProjectAndDateRangeParams{
+			ProjectID: projectID,
+			Since:     since,
+			Until:     until,
+		})
+		require.NoError(t, err)
+		require.Len(t, results, 2, "should return both Feb 22 and Feb 23 logs")
+
+		contents := make([]string, len(results))
+		for i, r := range results {
+			contents[i] = r.Content
+		}
+		assert.Contains(t, contents, "finished this and that")
+		assert.Contains(t, contents, "previous day log")
+		assert.NotContains(t, contents, "old log", "Feb 15 log should be outside the range")
+	})
+
+	t.Run("returns empty when range is in the future", func(t *testing.T) {
+		t.Parallel()
+		db := fixtures.SetupTestDB(t)
+		adapter := sqlite_adapter.New(db)
+		projectID := int64(fixtures.CreateTestProject(t, db, d, "future-range"))
+
+		ts := time.Date(2026, 2, 23, 17, 13, 2, 0, time.UTC).Format("2006-01-02 15:04:05")
+		_, err := db.ExecContext(ctx,
+			"INSERT INTO standup_logs (project_id, content, created_at) VALUES (?, ?, ?)",
+			projectID, "a log", ts)
+		require.NoError(t, err)
+
+		since := time.Date(2027, 1, 1, 0, 0, 0, 0, time.UTC)
+		until := time.Date(2027, 1, 8, 0, 0, 0, 0, time.UTC)
+
+		results, err := adapter.GetStandupLogsByProjectAndDateRange(ctx, types.GetStandupLogsByProjectAndDateRangeParams{
+			ProjectID: projectID,
+			Since:     since,
+			Until:     until,
+		})
+		require.NoError(t, err)
+		assert.Empty(t, results)
+	})
+
+	t.Run("returns empty when range predates all logs", func(t *testing.T) {
+		t.Parallel()
+		db := fixtures.SetupTestDB(t)
+		adapter := sqlite_adapter.New(db)
+		projectID := int64(fixtures.CreateTestProject(t, db, d, "past-range"))
+
+		ts := time.Date(2026, 2, 23, 17, 13, 2, 0, time.UTC).Format("2006-01-02 15:04:05")
+		_, err := db.ExecContext(ctx,
+			"INSERT INTO standup_logs (project_id, content, created_at) VALUES (?, ?, ?)",
+			projectID, "a log", ts)
+		require.NoError(t, err)
+
+		since := time.Date(2025, 1, 1, 0, 0, 0, 0, time.UTC)
+		until := time.Date(2025, 1, 8, 0, 0, 0, 0, time.UTC)
+
+		results, err := adapter.GetStandupLogsByProjectAndDateRange(ctx, types.GetStandupLogsByProjectAndDateRangeParams{
+			ProjectID: projectID,
+			Since:     since,
+			Until:     until,
+		})
+		require.NoError(t, err)
+		assert.Empty(t, results)
+	})
+
+	t.Run("until boundary is exclusive", func(t *testing.T) {
+		t.Parallel()
+		db := fixtures.SetupTestDB(t)
+		adapter := sqlite_adapter.New(db)
+		projectID := int64(fixtures.CreateTestProject(t, db, d, "until-exclusive"))
+
+		logAt := time.Date(2026, 2, 23, 17, 13, 2, 0, time.UTC)
+		ts := logAt.Format("2006-01-02 15:04:05")
+		_, err := db.ExecContext(ctx,
+			"INSERT INTO standup_logs (project_id, content, created_at) VALUES (?, ?, ?)",
+			projectID, "test", ts)
+		require.NoError(t, err)
+
+		// until = exactly the log timestamp — should NOT be included (<, not <=)
+		since := time.Date(2026, 2, 23, 0, 0, 0, 0, time.UTC)
+		until := logAt
+
+		results, err := adapter.GetStandupLogsByProjectAndDateRange(ctx, types.GetStandupLogsByProjectAndDateRangeParams{
+			ProjectID: projectID,
+			Since:     since,
+			Until:     until,
+		})
+		require.NoError(t, err)
+		assert.Empty(t, results, "log at exact 'until' boundary should be excluded")
+	})
+
+	t.Run("since boundary is inclusive", func(t *testing.T) {
+		t.Parallel()
+		db := fixtures.SetupTestDB(t)
+		adapter := sqlite_adapter.New(db)
+		projectID := int64(fixtures.CreateTestProject(t, db, d, "since-inclusive"))
+
+		logAt := time.Date(2026, 2, 22, 10, 0, 0, 0, time.UTC)
+		ts := logAt.Format("2006-01-02 15:04:05")
+		_, err := db.ExecContext(ctx,
+			"INSERT INTO standup_logs (project_id, content, created_at) VALUES (?, ?, ?)",
+			projectID, "boundary log", ts)
+		require.NoError(t, err)
+
+		// since = exactly the log timestamp — should be included (>=)
+		since := logAt
+		until := time.Date(2026, 2, 23, 0, 0, 0, 0, time.UTC)
+
+		results, err := adapter.GetStandupLogsByProjectAndDateRange(ctx, types.GetStandupLogsByProjectAndDateRangeParams{
+			ProjectID: projectID,
+			Since:     since,
+			Until:     until,
+		})
+		require.NoError(t, err)
+		require.Len(t, results, 1, "log at exact 'since' boundary should be included")
+		assert.Equal(t, "boundary log", results[0].Content)
+	})
+
+	t.Run("only returns logs for the specified project", func(t *testing.T) {
+		t.Parallel()
+		db := fixtures.SetupTestDB(t)
+		adapter := sqlite_adapter.New(db)
+		projectID := int64(fixtures.CreateTestProject(t, db, d, "project-filter"))
+		otherProjectID := int64(fixtures.CreateTestProject(t, db, d, "other-project"))
+
+		ts := time.Date(2026, 2, 23, 12, 0, 0, 0, time.UTC).Format("2006-01-02 15:04:05")
+		_, err := db.ExecContext(ctx,
+			"INSERT INTO standup_logs (project_id, content, created_at) VALUES (?, ?, ?)",
+			projectID, "my log", ts)
+		require.NoError(t, err)
+		_, err = db.ExecContext(ctx,
+			"INSERT INTO standup_logs (project_id, content, created_at) VALUES (?, ?, ?)",
+			otherProjectID, "other log", ts)
+		require.NoError(t, err)
+
+		since := time.Date(2026, 2, 16, 0, 0, 0, 0, time.UTC)
+		until := time.Date(2026, 2, 24, 0, 0, 0, 0, time.UTC)
+
+		results, err := adapter.GetStandupLogsByProjectAndDateRange(ctx, types.GetStandupLogsByProjectAndDateRangeParams{
+			ProjectID: projectID,
+			Since:     since,
+			Until:     until,
+		})
+		require.NoError(t, err)
+		require.Len(t, results, 1)
+		assert.Equal(t, projectID, results[0].ProjectID)
+	})
+
+	t.Run("results are ordered newest first", func(t *testing.T) {
+		t.Parallel()
+		db := fixtures.SetupTestDB(t)
+		adapter := sqlite_adapter.New(db)
+		projectID := int64(fixtures.CreateTestProject(t, db, d, "ordering"))
+
+		for _, entry := range []struct {
+			content string
+			at      time.Time
+		}{
+			{"oldest", time.Date(2026, 2, 20, 8, 0, 0, 0, time.UTC)},
+			{"middle", time.Date(2026, 2, 21, 10, 0, 0, 0, time.UTC)},
+			{"newest", time.Date(2026, 2, 23, 17, 0, 0, 0, time.UTC)},
+		} {
+			ts := entry.at.Format("2006-01-02 15:04:05")
+			_, err := db.ExecContext(ctx,
+				"INSERT INTO standup_logs (project_id, content, created_at) VALUES (?, ?, ?)",
+				projectID, entry.content, ts)
+			require.NoError(t, err)
+		}
+
+		since := time.Date(2026, 2, 16, 0, 0, 0, 0, time.UTC)
+		until := time.Date(2026, 2, 24, 0, 0, 0, 0, time.UTC)
+
+		results, err := adapter.GetStandupLogsByProjectAndDateRange(ctx, types.GetStandupLogsByProjectAndDateRangeParams{
+			ProjectID: projectID,
+			Since:     since,
+			Until:     until,
+		})
+		require.NoError(t, err)
+		require.Len(t, results, 3)
+		assert.Equal(t, "newest", results[0].Content)
+		assert.Equal(t, "middle", results[1].Content)
+		assert.Equal(t, "oldest", results[2].Content)
+	})
+
+	t.Run("returned created_at is parseable as UTC", func(t *testing.T) {
+		t.Parallel()
+		db := fixtures.SetupTestDB(t)
+		adapter := sqlite_adapter.New(db)
+		projectID := int64(fixtures.CreateTestProject(t, db, d, "created-at-utc"))
+
+		logAt := time.Date(2026, 2, 23, 17, 13, 2, 0, time.UTC)
+		ts := logAt.Format("2006-01-02 15:04:05")
+		_, err := db.ExecContext(ctx,
+			"INSERT INTO standup_logs (project_id, content, created_at) VALUES (?, ?, ?)",
+			projectID, "test", ts)
+		require.NoError(t, err)
+
+		since := time.Date(2026, 2, 23, 17, 0, 0, 0, time.UTC)
+		until := time.Date(2026, 2, 23, 18, 0, 0, 0, time.UTC)
+
+		results, err := adapter.GetStandupLogsByProjectAndDateRange(ctx, types.GetStandupLogsByProjectAndDateRangeParams{
+			ProjectID: projectID,
+			Since:     since,
+			Until:     until,
+		})
+		require.NoError(t, err)
+		require.Len(t, results, 1)
+
+		got := results[0].CreatedAt
+		require.True(t, got.Valid, "created_at should be non-NULL")
+		utc := got.Time.UTC()
+		assert.Equal(t, 2026, utc.Year())
+		assert.Equal(t, time.February, utc.Month())
+		assert.Equal(t, 23, utc.Day())
+		assert.Equal(t, 17, utc.Hour())
+		assert.Equal(t, 13, utc.Minute())
+		assert.Equal(t, 2, utc.Second())
+	})
+}
+
+// TestStandupLogDateRangeQuery_SQLite_TimezoneEdgeCases tests edge cases around UTC
+// timezone boundaries — the root cause of the original bug.
+func TestStandupLogDateRangeQuery_SQLite_TimezoneEdgeCases(t *testing.T) {
+	t.Parallel()
+	ctx := context.Background()
+	d := fixtures.SQLiteDialect()
+
+	t.Run("UTC midnight boundaries span the full day", func(t *testing.T) {
+		t.Parallel()
+		db := fixtures.SetupTestDB(t)
+		adapter := sqlite_adapter.New(db)
+		projectID := int64(fixtures.CreateTestProject(t, db, d, "midnight-span"))
+
+		insertAt := func(content string, at time.Time) {
+			t.Helper()
+			ts := at.UTC().Format("2006-01-02 15:04:05")
+			_, err := db.ExecContext(ctx,
+				"INSERT INTO standup_logs (project_id, content, created_at) VALUES (?, ?, ?)",
+				projectID, content, ts)
+			require.NoError(t, err)
+		}
+
+		// User in UTC-6: logs at 5:13 PM local (CST) = 23:13 UTC on Feb 22.
+		insertAt("evening local time", time.Date(2026, 2, 22, 23, 13, 0, 0, time.UTC))
+		// User in UTC+9 (JST): logs at 8 AM local Feb 23 = Feb 22 23:00 UTC.
+		insertAt("morning JST same UTC day", time.Date(2026, 2, 22, 23, 0, 0, 0, time.UTC))
+
+		// UTC-based range: midnight-to-midnight on Feb 22 UTC
+		since := time.Date(2026, 2, 22, 0, 0, 0, 0, time.UTC)
+		until := time.Date(2026, 2, 23, 0, 0, 0, 0, time.UTC)
+
+		results, err := adapter.GetStandupLogsByProjectAndDateRange(ctx, types.GetStandupLogsByProjectAndDateRangeParams{
+			ProjectID: projectID,
+			Since:     since,
+			Until:     until,
+		})
+		require.NoError(t, err)
+		assert.Len(t, results, 2, "both logs at 23:00 and 23:13 UTC on Feb 22 should be found")
+	})
+
+	t.Run("log at 23:59:59 UTC is within same-day UTC range", func(t *testing.T) {
+		t.Parallel()
+		db := fixtures.SetupTestDB(t)
+		adapter := sqlite_adapter.New(db)
+		projectID := int64(fixtures.CreateTestProject(t, db, d, "late-night-utc"))
+
+		ts := time.Date(2026, 2, 22, 23, 59, 59, 0, time.UTC).Format("2006-01-02 15:04:05")
+		_, err := db.ExecContext(ctx,
+			"INSERT INTO standup_logs (project_id, content, created_at) VALUES (?, ?, ?)",
+			projectID, "late night log", ts)
+		require.NoError(t, err)
+
+		since := time.Date(2026, 2, 22, 0, 0, 0, 0, time.UTC)
+		until := time.Date(2026, 2, 23, 0, 0, 0, 0, time.UTC)
+
+		results, err := adapter.GetStandupLogsByProjectAndDateRange(ctx, types.GetStandupLogsByProjectAndDateRangeParams{
+			ProjectID: projectID,
+			Since:     since,
+			Until:     until,
+		})
+		require.NoError(t, err)
+		require.Len(t, results, 1)
+		assert.Equal(t, "late night log", results[0].Content)
+	})
+
+	t.Run("log at midnight UTC is NOT in previous day range", func(t *testing.T) {
+		t.Parallel()
+		db := fixtures.SetupTestDB(t)
+		adapter := sqlite_adapter.New(db)
+		projectID := int64(fixtures.CreateTestProject(t, db, d, "midnight-boundary"))
+
+		// Log exactly at Feb 23 00:00:00 UTC — the exclusive 'until' boundary for Feb 22
+		ts := time.Date(2026, 2, 23, 0, 0, 0, 0, time.UTC).Format("2006-01-02 15:04:05")
+		_, err := db.ExecContext(ctx,
+			"INSERT INTO standup_logs (project_id, content, created_at) VALUES (?, ?, ?)",
+			projectID, "midnight log", ts)
+		require.NoError(t, err)
+
+		// Range is Feb 22 only
+		since := time.Date(2026, 2, 22, 0, 0, 0, 0, time.UTC)
+		until := time.Date(2026, 2, 23, 0, 0, 0, 0, time.UTC)
+
+		results, err := adapter.GetStandupLogsByProjectAndDateRange(ctx, types.GetStandupLogsByProjectAndDateRangeParams{
+			ProjectID: projectID,
+			Since:     since,
+			Until:     until,
+		})
+		require.NoError(t, err)
+		assert.Empty(t, results, "log at midnight (exclusive 'until') should not appear in Feb 22 range")
+
+		// But it SHOULD appear in the Feb 23 range
+		results, err = adapter.GetStandupLogsByProjectAndDateRange(ctx, types.GetStandupLogsByProjectAndDateRangeParams{
+			ProjectID: projectID,
+			Since:     time.Date(2026, 2, 23, 0, 0, 0, 0, time.UTC),
+			Until:     time.Date(2026, 2, 24, 0, 0, 0, 0, time.UTC),
+		})
+		require.NoError(t, err)
+		require.Len(t, results, 1)
+		assert.Equal(t, "midnight log", results[0].Content)
+	})
+}
+
+// TestStandupLogCreateAndRetrieve_SQLite verifies the round-trip: create via DEFAULT
+// CURRENT_TIMESTAMP (UTC in SQLite) and retrieve. The created_at should be valid and recent.
+func TestStandupLogCreateAndRetrieve_SQLite(t *testing.T) {
+	t.Parallel()
+
+	db := fixtures.SetupTestDB(t)
+	adapter := sqlite_adapter.New(db)
+	ctx := context.Background()
+
+	d := fixtures.SQLiteDialect()
+	projectID := int64(fixtures.CreateTestProject(t, db, d, "create-retrieve"))
+
+	before := time.Now().UTC().Truncate(time.Second)
+
+	created, err := adapter.CreateStandupLog(ctx, types.CreateStandupLogParams{
+		ProjectID: projectID,
+		Content:   "test entry",
+	})
+	require.NoError(t, err)
+
+	after := time.Now().UTC().Add(time.Second)
+
+	assert.Equal(t, projectID, created.ProjectID)
+	assert.Equal(t, "test entry", created.Content)
+	require.True(t, created.CreatedAt.Valid, "created_at should be valid (non-NULL)")
+	assert.False(t, created.CreatedAt.Time.IsZero(), "created_at should not be zero")
+
+	utcTime := created.CreatedAt.Time.UTC()
+	assert.True(t, !utcTime.Before(before) && !utcTime.After(after),
+		fmt.Sprintf("created_at (%v) should be between %v and %v", utcTime, before, after))
+}


### PR DESCRIPTION
## Checklist
- [x] Read `CONTRIBUTING.md`
- [x] Ran tests (`go test ./... -race`) locally
- [x] Formatted and linted with `gofmt -w .` and `golangci-lint run ./...` respectively
- [x] Added tests if necessary (significant changes/complex logic)
- [x] Updated documentation if applicable
- [x] Updated `README.md` if applicable

## Summary
<!--
What does this PR change and/or fix? 
Examples:
Closes: 54
Fixes: 67
-->
fixes an issue where logging wouldnt show in the generate. 
Standup section of the application 