### PR TITLE
Feature 143 DCC Expand Home Dir

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -4,7 +4,7 @@ First of all, thank you for considering contributing to this project!
 
 ## Some Ceremonial Stuff
 
-Run `./scripts/pre-commit.sh` before starting any work. This will install `gofmt` precommit hook.
+Run `./scripts/install-hooks.sh` before starting any work. This will install `gofmt` precommit hook.
 
 Before you start any work, make sure you have a issue open, and have it assigned to yourself.
 

--- a/README.md
+++ b/README.md
@@ -125,13 +125,13 @@ Manage connections through the CLI or config file:
 
 ```bash
 # Add a SQLite database
-paso db add --name=local --connection="~/.paso/tasks.db" --type=sqlite
+paso db add ~/.paso/tasks.db -n local -l
 
 # Add a remote PostgreSQL database
-paso db add --name=remote --connection="postgres://user:pass@host/db" --type=postgres
+paso db add "postgres://user:pass@host/db" -n remote -r
 
 # Switch between them
-paso db connect --name=remote
+paso db connect remote
 ```
 
 ## External Integrations

--- a/internal/cli/db/add.go
+++ b/internal/cli/db/add.go
@@ -4,6 +4,8 @@ import (
 	"encoding/json"
 	"fmt"
 	"os"
+	"path/filepath"
+	"strings"
 
 	"github.com/spf13/cobra"
 	"github.com/thenoetrevino/paso/internal/cli"
@@ -47,8 +49,23 @@ Examples:
 	return cmd
 }
 
+func expandTilde(path string) (string, error) {
+	if !strings.HasPrefix(path, "~/") {
+		return path, nil
+	}
+	home, err := os.UserHomeDir()
+	if err != nil {
+		return "", fmt.Errorf("failed to resolve home directory: %w", err)
+	}
+	return filepath.Join(home, path[2:]), nil
+}
+
 func runAdd(cmd *cobra.Command, args []string) error {
-	connStr := args[0]
+	connStr, err := expandTilde(args[0])
+	if err != nil {
+		return err
+	}
+
 	name, _ := cmd.Flags().GetString("name")
 	remote, _ := cmd.Flags().GetBool("remote")
 	local, _ := cmd.Flags().GetBool("local")


### PR DESCRIPTION
## Checklist
- [x] Read `CONTRIBUTING.md`
- [x] Ran tests (`go test ./... -race`) locally
- [x] Formatted and linted with `gofmt -w .` and `golangci-lint run ./...` respectively
- [x] Added tests if necessary (significant changes/complex logic)
- [x] Updated documentation if applicable
- [x] Updated `README.md` if applicable

## Summary
Expands '~' into the home directory when defining a DB connection.
Updates db connection instructions.
Updates contributing.md install hooks filename
Closes: 143

## Note
IDK how to write go so let me know if there's a better way
