### PR TITLE
docs: note incremental header building in renderDetailHeader

### DIFF
--- a/internal/tui/components/detail_panel.go
+++ b/internal/tui/components/detail_panel.go
@@ -127,6 +127,7 @@ func renderDetailHeader(task *models.TaskDetail, width int) string {
 		Bold(true)
 
 	ticketNumber := fmt.Sprintf("%s-%d", task.ProjectName, task.TicketNumber)
+	// Build the header up incrementally: ticket number, title, then status.
 	var header strings.Builder
 	header.WriteString(ticketStyle.Render(ticketNumber))
 


### PR DESCRIPTION
Per review feedback, add a comment explaining that the header is built up incrementally with strings.Builder.

## Checklist
- [x] Read `CONTRIBUTING.md`
- [x] Ran tests (`go test ./... -race`) locally
- [x] Formatted and linted with `gofmt -w .` and `golangci-lint run ./...` respectively
- [x] Added tests if necessary (significant changes/complex logic)
- [x] Updated documentation if applicable
- [x] Updated `README.md` if applicable

## Summary
<!--
What does this PR change and/or fix? 
Examples:
Closes: 54
Fixes: 67
-->
Closes #147 