### PR TITLE
fix: preserve indentation when wrapping multiline task detail text

### DIFF
--- a/internal/cli/styles/styles.go
+++ b/internal/cli/styles/styles.go
@@ -3,11 +3,23 @@ package styles
 
 import (
 	"fmt"
+	"strings"
 	"sync"
 
 	"charm.land/lipgloss/v2"
+	"github.com/muesli/reflow/wordwrap"
+	"github.com/muesli/reflow/wrap"
 	"github.com/thenoetrevino/paso/internal/config/colors"
 	"github.com/thenoetrevino/paso/internal/models"
+)
+
+// CardPaddingX is the horizontal padding applied inside the card border
+// (on each side). CardBorderX is the width the rounded border consumes on each
+// side. Both are subtracted from CardWidth to get the usable text width, since
+// lipgloss counts the border within the configured Width.
+const (
+	CardPaddingX = 2
+	CardBorderX  = 1
 )
 
 var (
@@ -37,7 +49,7 @@ func Init(colors colors.ColorScheme) {
 		CardStyle = lipgloss.NewStyle().
 			Border(lipgloss.RoundedBorder()).
 			BorderForeground(lipgloss.Color(colors.Accent)).
-			Padding(1, 2).
+			Padding(1, CardPaddingX).
 			Width(CardWidth)
 
 		TitleStyle = lipgloss.NewStyle().
@@ -108,33 +120,70 @@ func RenderLabelChip(label *models.Label) string {
 		Render("[" + label.Name + "]")
 }
 
-// RenderTaskReference renders a task reference with colored bullet
-// Format: "• 123 - Title"
+// RenderTaskReference renders a task reference as an indented, word-wrapped
+// bullet. Format: "  • ProjectName-123 - Title". Long titles wrap with a
+// hanging indent so continuation lines stay aligned under the bullet text.
 func RenderTaskReference(ref *models.TaskReference) string {
-	bulletStyle := lipgloss.NewStyle().
-		Foreground(lipgloss.Color(ref.RelationColor))
-
 	taskRef := fmt.Sprintf("%s-%d - %s",
 		ref.ProjectName,
 		ref.TaskNumber,
 		ref.Title)
 
-	return bulletStyle.Render("• " + taskRef)
+	return renderBullet(taskRef, ref.RelationColor)
 }
 
 // RenderTaskReferenceWithLabel renders a task reference with relation label
-// Format: "• ProjectName-123 - RelationLabel - Title"
+// Format: "  • ProjectName-123 - RelationLabel - Title".
 func RenderTaskReferenceWithLabel(ref *models.TaskReference) string {
-	bulletStyle := lipgloss.NewStyle().
-		Foreground(lipgloss.Color(ref.RelationColor))
-
 	taskRef := fmt.Sprintf("%s-%d - %s - %s",
 		ref.ProjectName,
 		ref.TaskNumber,
 		ref.RelationLabel,
 		ref.Title)
 
-	return bulletStyle.Render("• " + taskRef)
+	return renderBullet(taskRef, ref.RelationColor)
+}
+
+// renderBullet renders text as a colored bullet list item, word-wrapped to the
+// card width. The first line is indented two spaces (under the section body)
+// and any wrapped continuation lines are indented four spaces so they align
+// under the bullet's text rather than collapsing to the card margin.
+func renderBullet(text, color string) string {
+	const firstIndent = "  "
+	const hangIndent = "    "
+
+	style := lipgloss.NewStyle().Foreground(lipgloss.Color(color))
+	lines := WrapText("• "+text, CardContentWidth()-len(hangIndent))
+
+	var b strings.Builder
+	for i, line := range lines {
+		if i > 0 {
+			b.WriteString("\n")
+		}
+		indent := firstIndent
+		if i > 0 {
+			indent = hangIndent
+		}
+		b.WriteString(indent + style.Render(line))
+	}
+	return b.String()
+}
+
+// CardContentWidth returns the usable text width inside a card, i.e. the card
+// width minus its border and horizontal padding on both sides.
+func CardContentWidth() int {
+	return CardWidth - (CardBorderX+CardPaddingX)*2
+}
+
+// WrapText word-wraps s to at most limit cells per line, breaking on word
+// boundaries and hard-breaking any single word longer than the limit. Existing
+// newlines in s are preserved as hard line breaks.
+func WrapText(s string, limit int) []string {
+	if limit < 1 {
+		limit = 1
+	}
+	wrapped := wrap.String(wordwrap.String(s, limit), limit)
+	return strings.Split(wrapped, "\n")
 }
 
 // RenderCard wraps content in a styled card border

--- a/internal/cli/styles/styles_test.go
+++ b/internal/cli/styles/styles_test.go
@@ -4,6 +4,7 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/mattn/go-runewidth"
 	"github.com/stretchr/testify/assert"
 	"github.com/thenoetrevino/paso/internal/config/colors"
 	"github.com/thenoetrevino/paso/internal/models"
@@ -163,9 +164,10 @@ func TestRenderTaskReferenceWrapsWithHangingIndent(t *testing.T) {
 		assert.True(t, strings.HasPrefix(l, "    "), "continuation %q lost its hanging indent", l)
 		assert.False(t, strings.HasPrefix(l, "    •"), "continuation %q should not repeat the bullet", l)
 	}
-	// Every line stays within the card content width.
+	// Every line stays within the card content width. Measure visual columns
+	// (not bytes), matching how the wrap library and CardContentWidth count.
 	for _, l := range lines {
-		assert.LessOrEqual(t, len(l), CardContentWidth(), "line %q exceeds card width", l)
+		assert.LessOrEqual(t, runewidth.StringWidth(l), CardContentWidth(), "line %q exceeds card width", l)
 	}
 }
 

--- a/internal/cli/styles/styles_test.go
+++ b/internal/cli/styles/styles_test.go
@@ -1,6 +1,7 @@
 package styles
 
 import (
+	"strings"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -104,6 +105,68 @@ func TestRenderCard(t *testing.T) {
 
 	result := RenderCard("card content")
 	assert.Contains(t, result, "card content")
+}
+
+func TestCardContentWidth(t *testing.T) {
+	t.Parallel()
+	// CardWidth includes the border and horizontal padding on both sides, so
+	// the usable text width is narrower than CardWidth itself.
+	assert.Equal(t, CardWidth-(CardBorderX+CardPaddingX)*2, CardContentWidth())
+	assert.Less(t, CardContentWidth(), CardWidth)
+}
+
+func TestWrapText(t *testing.T) {
+	t.Parallel()
+
+	t.Run("wraps on word boundaries within the limit", func(t *testing.T) {
+		t.Parallel()
+		lines := WrapText("the quick brown fox jumps", 10)
+		for _, l := range lines {
+			assert.LessOrEqual(t, len(l), 10, "line %q exceeds limit", l)
+		}
+		assert.Equal(t, "the quick brown fox jumps", strings.Join(lines, " "))
+	})
+
+	t.Run("hard-breaks words longer than the limit", func(t *testing.T) {
+		t.Parallel()
+		lines := WrapText("supercalifragilistic", 5)
+		assert.Greater(t, len(lines), 1)
+		for _, l := range lines {
+			assert.LessOrEqual(t, len(l), 5, "line %q exceeds limit", l)
+		}
+	})
+
+	t.Run("preserves existing newlines as hard breaks", func(t *testing.T) {
+		t.Parallel()
+		lines := WrapText("- one\n- two", 40)
+		assert.Equal(t, []string{"- one", "- two"}, lines)
+	})
+}
+
+func TestRenderTaskReferenceWrapsWithHangingIndent(t *testing.T) {
+	t.Parallel()
+	ref := &models.TaskReference{
+		TaskNumber:    42,
+		ProjectName:   "MyProject",
+		Title:         strings.Repeat("word ", 40), // forces wrapping
+		RelationColor: "#0000FF",
+	}
+
+	lines := strings.Split(stripANSI(RenderTaskReference(ref)), "\n")
+	assert.Greater(t, len(lines), 1, "long title should wrap onto multiple lines")
+
+	// First line carries the bullet at a two-space indent.
+	assert.True(t, strings.HasPrefix(lines[0], "  • "), "got %q", lines[0])
+	// Continuation lines hang under the bullet text at a four-space indent
+	// (and never collapse back to the card margin).
+	for _, l := range lines[1:] {
+		assert.True(t, strings.HasPrefix(l, "    "), "continuation %q lost its hanging indent", l)
+		assert.False(t, strings.HasPrefix(l, "    •"), "continuation %q should not repeat the bullet", l)
+	}
+	// Every line stays within the card content width.
+	for _, l := range lines {
+		assert.LessOrEqual(t, len(l), CardContentWidth(), "line %q exceeds card width", l)
+	}
 }
 
 func TestTreeConstants(t *testing.T) {

--- a/internal/cli/task/show_logic.go
+++ b/internal/cli/task/show_logic.go
@@ -212,7 +212,7 @@ func FormatShowHuman(task *models.TaskDetail, colorScheme colors.ColorScheme) st
 		content.WriteString(styles.SectionStyle.Render("Blocked By"))
 		content.WriteString("\n")
 		for _, child := range relationships.BlockingChildren {
-			content.WriteString("  " + styles.RenderTaskReference(child) + "\n")
+			content.WriteString(styles.RenderTaskReference(child) + "\n")
 		}
 	}
 
@@ -222,7 +222,7 @@ func FormatShowHuman(task *models.TaskDetail, colorScheme colors.ColorScheme) st
 		content.WriteString(styles.SectionStyle.Render("Blocking"))
 		content.WriteString("\n")
 		for _, parent := range relationships.BlockingParents {
-			content.WriteString("  " + styles.RenderTaskReference(parent) + "\n")
+			content.WriteString(styles.RenderTaskReference(parent) + "\n")
 		}
 	}
 
@@ -232,7 +232,7 @@ func FormatShowHuman(task *models.TaskDetail, colorScheme colors.ColorScheme) st
 		content.WriteString(styles.SectionStyle.Render("Parent Tasks"))
 		content.WriteString("\n")
 		for _, parent := range relationships.NonBlockingParents {
-			content.WriteString("  " + styles.RenderTaskReferenceWithLabel(parent) + "\n")
+			content.WriteString(styles.RenderTaskReferenceWithLabel(parent) + "\n")
 		}
 	}
 
@@ -242,7 +242,7 @@ func FormatShowHuman(task *models.TaskDetail, colorScheme colors.ColorScheme) st
 		content.WriteString(styles.SectionStyle.Render("Child Tasks"))
 		content.WriteString("\n")
 		for _, child := range relationships.NonBlockingChildren {
-			content.WriteString("  " + styles.RenderTaskReferenceWithLabel(child) + "\n")
+			content.WriteString(styles.RenderTaskReferenceWithLabel(child) + "\n")
 		}
 	}
 

--- a/internal/cli/task/task_helpers.go
+++ b/internal/cli/task/task_helpers.go
@@ -4,6 +4,8 @@ import (
 	"strings"
 
 	"charm.land/lipgloss/v2"
+
+	"github.com/thenoetrevino/paso/internal/cli/styles"
 )
 
 // ShouldDisplayPriority returns true if priority should be shown in output
@@ -31,9 +33,15 @@ func DisplayOrDefault(ptr *string, defaultVal string) string {
 	return defaultVal
 }
 
-// WriteIndentedLines writes text to a builder with each line indented and styled
+// WriteIndentedLines writes text to a builder with each line indented and
+// styled. Lines wider than the card content area are word-wrapped to the same
+// indent so they don't get re-wrapped (and lose their indentation) when the
+// card border is rendered.
 func WriteIndentedLines(builder *strings.Builder, text string, indent string, style lipgloss.Style) {
-	for line := range strings.SplitSeq(text, "\n") {
-		builder.WriteString(indent + style.Render(line) + "\n")
+	limit := styles.CardContentWidth() - len(indent)
+	for src := range strings.SplitSeq(text, "\n") {
+		for _, line := range styles.WrapText(src, limit) {
+			builder.WriteString(indent + style.Render(line) + "\n")
+		}
 	}
 }

--- a/internal/cli/task/task_helpers_test.go
+++ b/internal/cli/task/task_helpers_test.go
@@ -1,0 +1,49 @@
+package task
+
+import (
+	"regexp"
+	"strings"
+	"testing"
+
+	"charm.land/lipgloss/v2"
+	"github.com/stretchr/testify/assert"
+
+	"github.com/thenoetrevino/paso/internal/cli/styles"
+)
+
+var ansiPattern = regexp.MustCompile(`\x1b\[[0-9;]*m`)
+
+func stripANSI(s string) string {
+	return ansiPattern.ReplaceAllString(s, "")
+}
+
+func TestWriteIndentedLines(t *testing.T) {
+	t.Parallel()
+
+	t.Run("indents every source line", func(t *testing.T) {
+		t.Parallel()
+		var b strings.Builder
+		WriteIndentedLines(&b, "alpha\nbeta", "  ", lipgloss.NewStyle())
+
+		lines := strings.Split(strings.TrimRight(stripANSI(b.String()), "\n"), "\n")
+		assert.Equal(t, []string{"  alpha", "  beta"}, lines)
+	})
+
+	t.Run("wraps long lines to the same indent within the card width", func(t *testing.T) {
+		t.Parallel()
+		indent := "    "
+		long := strings.Repeat("word ", 40)
+
+		var b strings.Builder
+		WriteIndentedLines(&b, long, indent, lipgloss.NewStyle())
+
+		lines := strings.Split(strings.TrimRight(stripANSI(b.String()), "\n"), "\n")
+		assert.Greater(t, len(lines), 1, "long text should wrap")
+		for _, l := range lines {
+			// Continuation lines keep the indent instead of collapsing to the margin.
+			assert.True(t, strings.HasPrefix(l, indent), "line %q lost its indent", l)
+			// And stay within the card so the border render doesn't re-wrap them.
+			assert.LessOrEqual(t, len(l), styles.CardContentWidth(), "line %q exceeds card width", l)
+		}
+	})
+}

--- a/internal/cli/task/task_helpers_test.go
+++ b/internal/cli/task/task_helpers_test.go
@@ -1,21 +1,16 @@
 package task
 
 import (
-	"regexp"
 	"strings"
 	"testing"
 
 	"charm.land/lipgloss/v2"
+	"github.com/mattn/go-runewidth"
 	"github.com/stretchr/testify/assert"
 
 	"github.com/thenoetrevino/paso/internal/cli/styles"
+	"github.com/thenoetrevino/paso/internal/testing/fixtures"
 )
-
-var ansiPattern = regexp.MustCompile(`\x1b\[[0-9;]*m`)
-
-func stripANSI(s string) string {
-	return ansiPattern.ReplaceAllString(s, "")
-}
 
 func TestWriteIndentedLines(t *testing.T) {
 	t.Parallel()
@@ -25,7 +20,7 @@ func TestWriteIndentedLines(t *testing.T) {
 		var b strings.Builder
 		WriteIndentedLines(&b, "alpha\nbeta", "  ", lipgloss.NewStyle())
 
-		lines := strings.Split(strings.TrimRight(stripANSI(b.String()), "\n"), "\n")
+		lines := strings.Split(strings.TrimRight(fixtures.StripANSI(b.String()), "\n"), "\n")
 		assert.Equal(t, []string{"  alpha", "  beta"}, lines)
 	})
 
@@ -37,13 +32,15 @@ func TestWriteIndentedLines(t *testing.T) {
 		var b strings.Builder
 		WriteIndentedLines(&b, long, indent, lipgloss.NewStyle())
 
-		lines := strings.Split(strings.TrimRight(stripANSI(b.String()), "\n"), "\n")
+		lines := strings.Split(strings.TrimRight(fixtures.StripANSI(b.String()), "\n"), "\n")
 		assert.Greater(t, len(lines), 1, "long text should wrap")
 		for _, l := range lines {
 			// Continuation lines keep the indent instead of collapsing to the margin.
 			assert.True(t, strings.HasPrefix(l, indent), "line %q lost its indent", l)
 			// And stay within the card so the border render doesn't re-wrap them.
-			assert.LessOrEqual(t, len(l), styles.CardContentWidth(), "line %q exceeds card width", l)
+			// Measure visual columns (not bytes) since the wrap library and the
+			// card width are both in terminal cells.
+			assert.LessOrEqual(t, runewidth.StringWidth(l), styles.CardContentWidth(), "line %q exceeds card width", l)
 		}
 	})
 }


### PR DESCRIPTION
Closes: #151

## Summary

Fixes #151 — `paso task show` rendered multiline descriptions, comments, and relationship bullets as a "stream of text" instead of preserving their structure.

### Root cause
The detail card builds content with manual indents, bullets, and newlines, then hands the whole string to a fixed-`Width` lipgloss card. lipgloss preserves hard newlines but **re-wraps any over-long line and drops the continuation to the card margin**, discarding the manual indent. There was also an off-by: in this lipgloss version `Width` *includes* the border, so the usable content width is `80 − border(2) − padding(4) = 74`, not 76.

### Fix
Wrap the text ourselves to the card's real content width with a **hanging indent**, so continuation lines stay aligned and lipgloss never needs to re-wrap.

- `styles.go`: add `CardContentWidth()`, `WrapText()` (word-wrap + hard-break long words), and `renderBullet()` (2-space first indent, 4-space hanging indent). `RenderTaskReference`/`…WithLabel` route through it.
- `task_helpers.go`: `WriteIndentedLines` (descriptions + comments) now wraps each line to the indent-aware width.
- `show_logic.go`: dropped the now-redundant manual `"  "` prefix on the four relationship bullet call sites.

### Before / after (wrapped blocker)
```
Before:                                      After:
  • …-10 - Create OrderRepository (session     • …-10 - Create OrderRepository (session
lookup, token lookup, atomic email guard)        lookup, token lookup, atomic email guard)
```

## Testing
- Added tests for `CardContentWidth`, `WrapText`, the bullet hanging indent, and `WriteIndentedLines` wrapping.
- Verified manually via `go run main.go task show 233`.
- `go build`, `go vet`, `gofmt`, and the styles/task suites pass.

Note: two pre-existing failures in `internal/tui/activity_view_test.go` are unrelated (confirmed failing on a clean tree).
